### PR TITLE
Refactor current configuration with Factory design pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ SRC	:=	$(COMMON_SRC) \
 		$(MATH_SRC) \
 		src/main.cpp \
 		src/Raytracer.cpp \
+		src/Factory.cpp \
 		src/Config.cpp \
 		src/DLLoader.cpp \
 		src/Camera.cpp \

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ SRC	:=	$(COMMON_SRC) \
 		$(MATH_SRC) \
 		src/main.cpp \
 		src/Raytracer.cpp \
+		src/Config.cpp \
 		src/Camera.cpp \
 		src/Ray.cpp
 

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ SRC	:=	$(COMMON_SRC) \
 		src/main.cpp \
 		src/Raytracer.cpp \
 		src/Config.cpp \
+		src/DLLoader.cpp \
 		src/Camera.cpp \
 		src/Ray.cpp
 

--- a/include/Camera.hpp
+++ b/include/Camera.hpp
@@ -8,11 +8,14 @@ namespace Raytracer {
     class Camera {
         public:
             Camera();
-            Camera(const Math::Point3D origin, const Math::Rectangle3D screen);
+            Camera(const Math::Point3D origin, const Math::Rectangle3D screen,
+                const std::size_t width, const std::size_t height);
             ~Camera() = default;
 
             Math::Point3D origin;
             Math::Rectangle3D screen;
+            std::size_t width;
+            std::size_t height;
 
             Raytracer::Ray ray(double u, double v);
     };

--- a/include/Config.hpp
+++ b/include/Config.hpp
@@ -29,8 +29,7 @@ namespace Raytracer {
             std::optional<std::reference_wrapper<libconfig::Setting>> _root;
 
             // TODO: move to factory
-            std::map<const std::string, std::shared_ptr<DLLoader<IPrimitive>>> _primitiveLoaders;
-            std::map<const std::string, std::shared_ptr<DLLoader<ILight>>> _lightLoaders;
+            std::map<const std::string, std::shared_ptr<DLLoader>> _loaders;
 
             Color parseColor(const libconfig::Setting &setting) const;
     };

--- a/include/Config.hpp
+++ b/include/Config.hpp
@@ -1,12 +1,11 @@
 #pragma once
 
 #include "Camera.hpp"
-#include "DLLoader.hpp"
+#include "Factory.hpp"
 #include "lights/ILight.hpp"
 #include "primitives/IPrimitive.hpp"
 #include <functional>
 #include <libconfig.h++>
-#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -28,8 +27,7 @@ namespace Raytracer {
             libconfig::Config _config;
             std::optional<std::reference_wrapper<libconfig::Setting>> _root;
 
-            // TODO: move to factory
-            std::map<const std::string, std::shared_ptr<DLLoader>> _loaders;
+            Factory _factory;
 
             Color parseColor(const libconfig::Setting &setting) const;
     };

--- a/include/Config.hpp
+++ b/include/Config.hpp
@@ -30,5 +30,7 @@ namespace Raytracer {
             Factory _factory;
 
             Color parseColor(const libconfig::Setting &setting) const;
+            PrimitiveOptions parsePrimitiveOptions(const libconfig::Setting &setting) const;
+            LightOptions parseLightOptions(const libconfig::Setting &setting) const;
     };
 }

--- a/include/Config.hpp
+++ b/include/Config.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "Camera.hpp"
+#include "DLLoader.hpp"
+#include "lights/ILight.hpp"
+#include "primitives/IPrimitive.hpp"
+#include <functional>
+#include <libconfig.h++>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace Raytracer {
+    class Config {
+        public:
+            Config() = delete;
+            Config(const std::string fileName);
+            ~Config() = default;
+
+            Camera parseCamera() const;
+            std::vector<std::shared_ptr<IPrimitive>> parsePrimitives();
+            std::vector<std::shared_ptr<ILight>> parseLights();
+
+        private:
+            const std::string _fileName;
+
+            libconfig::Config _config;
+            std::optional<std::reference_wrapper<libconfig::Setting>> _root;
+
+            // TODO: move to factory
+            std::map<const std::string, std::shared_ptr<DLLoader<IPrimitive>>> _primitiveLoaders;
+            std::map<const std::string, std::shared_ptr<DLLoader<ILight>>> _lightLoaders;
+
+            Color parseColor(const libconfig::Setting &setting) const;
+    };
+}

--- a/include/DLLoader.hpp
+++ b/include/DLLoader.hpp
@@ -1,50 +1,30 @@
 #pragma once
 
 #include "Exception.hpp"
-#include "lights/LightOptions.hpp"
-#include "primitives/PrimitiveOptions.hpp"
 #include <dlfcn.h>
 #include <memory>
 #include <string>
 
 namespace Raytracer {
-    template <typename T>
     class DLLoader {
         public:
             DLLoader() = delete;
 
-            DLLoader(const std::string libraryName) : _libraryName(libraryName), _handle(nullptr)
-            {
-                openHandle();
-            };
+            DLLoader(const std::string libraryName);
 
-            ~DLLoader()
-            {
-                closeHandle();
-            };
+            ~DLLoader();
 
-            void *openHandle()
-            {
-                _handle = dlopen(_libraryName.c_str(), RTLD_NOW);
-                if (_handle == nullptr)
-                    throw Raytracer::Exception(dlerror());
-                return _handle;
-            }
+            void *openHandle();
 
-            bool symbolExists(const std::string symbol) const
-            {
-                if (_handle == nullptr)
-                    return false;
+            bool symbolExists(const std::string symbol) const;
 
-                return dlsym(_handle, symbol.c_str()) != nullptr;
-            }
-
-            std::shared_ptr<T> getInstance(const std::string functionName, Raytracer::PrimitiveOptions options) const
+            template <typename T, typename O>
+            std::shared_ptr<T> getInstance(const std::string functionName, O options) const
             {
                 if (_handle == nullptr)
                     throw Raytracer::Exception("Impossible to find handle");
 
-                T *(*function)(PrimitiveOptions) = reinterpret_cast<T *(*)(PrimitiveOptions)>(dlsym(_handle, functionName.c_str()));
+                T *(*function)(O) = reinterpret_cast<T *(*)(O)>(dlsym(_handle, functionName.c_str()));
                 if (function == nullptr)
                     throw Raytracer::Exception(dlerror());
 
@@ -55,31 +35,7 @@ namespace Raytracer {
                 return std::shared_ptr<T>(instance);
             };
 
-            std::shared_ptr<T> getInstance(const std::string functionName, Raytracer::LightOptions options) const
-            {
-                if (_handle == nullptr)
-                    throw Raytracer::Exception("Impossible to find handle");
-
-                T *(*function)(LightOptions) = reinterpret_cast<T *(*)(LightOptions)>(dlsym(_handle, functionName.c_str()));
-                if (function == nullptr)
-                    throw Raytracer::Exception(dlerror());
-
-                T *instance = (*function)(options);
-                if (instance == nullptr)
-                    throw Raytracer::Exception("Impossible to find instance");
-
-                return std::shared_ptr<T>(instance);
-            };
-
-            void closeHandle()
-            {
-                if (_handle == nullptr)
-                    return;
-                if (dlclose(_handle) != 0)
-                    throw Raytracer::Exception(dlerror());
-
-                _handle = nullptr;
-            }
+            void closeHandle();
 
         private:
             const std::string _libraryName;

--- a/include/DLLoader.hpp
+++ b/include/DLLoader.hpp
@@ -2,6 +2,7 @@
 
 #include "Exception.hpp"
 #include <dlfcn.h>
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -19,16 +20,25 @@ namespace Raytracer {
             bool symbolExists(const std::string symbol) const;
 
             template <typename T, typename O>
+            std::function<T *(O)> getSymbol(const std::string functionName) const
+            {
+                if (_handle == nullptr)
+                    throw Raytracer::Exception("Impossible to find handle");
+
+                return reinterpret_cast<T *(*)(O)>(dlsym(_handle, functionName.c_str()));
+            }
+
+            template <typename T, typename O>
             std::shared_ptr<T> getInstance(const std::string functionName, O options) const
             {
                 if (_handle == nullptr)
                     throw Raytracer::Exception("Impossible to find handle");
 
-                T *(*function)(O) = reinterpret_cast<T *(*)(O)>(dlsym(_handle, functionName.c_str()));
-                if (function == nullptr)
+                std::function<T *(O)> function = getSymbol<T, O>(functionName);
+                if (!function)
                     throw Raytracer::Exception(dlerror());
 
-                T *instance = (*function)(options);
+                T *instance = function(options);
                 if (instance == nullptr)
                     throw Raytracer::Exception("Impossible to find instance");
 

--- a/include/DLLoader.hpp
+++ b/include/DLLoader.hpp
@@ -29,6 +29,16 @@ namespace Raytracer {
             }
 
             template <typename T, typename O>
+            static std::shared_ptr<T> turnFunctionIntoInstance(std::function<T *(O)> function, O options)
+            {
+                T *instance = function(options);
+                if (instance == nullptr)
+                    throw Raytracer::Exception("Impossible to create instance");
+
+                return std::shared_ptr<T>(instance);
+            }
+
+            template <typename T, typename O>
             std::shared_ptr<T> getInstance(const std::string functionName, O options) const
             {
                 if (_handle == nullptr)
@@ -38,11 +48,7 @@ namespace Raytracer {
                 if (!function)
                     throw Raytracer::Exception(dlerror());
 
-                T *instance = function(options);
-                if (instance == nullptr)
-                    throw Raytracer::Exception("Impossible to find instance");
-
-                return std::shared_ptr<T>(instance);
+                return turnFunctionIntoInstance(function, options);
             };
 
             void closeHandle();

--- a/include/Factory.hpp
+++ b/include/Factory.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "DLLoader.hpp"
+#include "lights/ILight.hpp"
+#include "lights/LightOptions.hpp"
+#include "primitives/IPrimitive.hpp"
+#include "primitives/PrimitiveOptions.hpp"
+#include <unordered_map>
+#include <map>
+#include <memory>
+#include <string>
+
+namespace Raytracer {
+    class Factory {
+        public:
+            Factory();
+            ~Factory() = default;
+
+            void registerAllPlugins();
+            std::shared_ptr<IPrimitive> createPrimitive(const std::string name, PrimitiveOptions options);
+            std::shared_ptr<ILight> createLight(const std::string name, LightOptions options);
+
+        private:
+            struct PluginConfig {
+                // Category of the object (ex: "primitive")
+                std::string category;
+
+                // Name of the object (ex: "sphere")
+                std::string name;
+
+                bool operator==(const PluginConfig &other) const = default;
+            };
+
+            // For some unknown reason, I cannot use the "Custom specialization of std::hash"
+            // So I have to resort to this trickery to make std::unordered_map work
+            // See https://stackoverflow.com/questions/17016175/c-unordered-map-using-a-custom-class-type-as-the-key
+            // and https://en.cppreference.com/cpp/utility/hash
+            struct PluginConfigHash
+            {
+                std::size_t operator()(const PluginConfig& config) const noexcept
+                {
+                    std::size_t h1 = std::hash<std::string>{}(config.category);
+                    std::size_t h2 = std::hash<std::string>{}(config.name);
+                    return h1 ^ (h2 << 1);
+                }
+            };
+
+            std::map<const std::string, std::shared_ptr<DLLoader>> _loaders;
+            std::unordered_map<PluginConfig, std::function<IPrimitive *(PrimitiveOptions)>, PluginConfigHash> _primitives;
+            std::unordered_map<PluginConfig, std::function<ILight *(LightOptions)>, PluginConfigHash> _lights;
+    };
+}

--- a/include/Raytracer.hpp
+++ b/include/Raytracer.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
 #include "Camera.hpp"
+#include "Config.hpp"
 #include "lights/ILight.hpp"
-#include "DLLoader.hpp"
 #include "primitives/IPrimitive.hpp"
 #include <libconfig.h++>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -20,15 +19,11 @@ namespace Raytracer {
             void exportPPM();
         private:
             const std::string _sceneFile;
-            libconfig::Config _config;
+            Config _config;
 
             Camera _camera;
-            unsigned int _width;
-            unsigned int _height;
             void handleHit(std::shared_ptr<IPrimitive> &s, HitInfo &hit, Color &color);
 
-            std::map<const std::string, std::shared_ptr<DLLoader<ILight>>> _lightLoaders;
-            std::map<const std::string, std::shared_ptr<DLLoader<IPrimitive>>> _primitiveLoaders;
             std::vector<std::shared_ptr<IPrimitive>> _primitives;
             std::vector<std::shared_ptr<ILight>> _lights;
     };

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -5,4 +5,7 @@
 namespace Raytracer::Utils {
     constexpr std::string_view primitiveEntrypoint("primitiveEntrypoint");
     constexpr std::string_view lightEntrypoint("lightEntrypoint");
+
+    // Related to the binary path of the raytracer.
+    constexpr std::string_view pluginsDir("./plugins");
 }

--- a/scenes/bootstrap.cfg
+++ b/scenes/bootstrap.cfg
@@ -7,7 +7,7 @@ camera:
 
 primitives:
 {
-    spheres = (
+    sphere = (
         { x = 0; y = 0; z = -200; r = 120; color = { r = 255; g = 0; b = 0; }; },
     );
 };

--- a/scenes/example.cfg
+++ b/scenes/example.cfg
@@ -11,13 +11,13 @@ camera:
 primitives:
 {
     # List of spheres
-    spheres = (
+    sphere = (
         { x = 60; y = 5; z = 40; r = 25; color = { r = 255; g = 64; b = 64; }; },
         { x = -40; y = 20; z = -10; r = 35; color = { r = 64; g = 255; b = 64; }; }
     );
 
     # List of planes
-    planes = (
+    plane = (
         { axis = "Z"; position = -20; color = { r = 64; g = 64; b = 255; }; }
     );
 };

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -3,12 +3,13 @@
 #include "Camera.hpp"
 #include "Ray.hpp"
 
-Raytracer::Camera::Camera() : origin(0, 0, 0), screen()
+Raytracer::Camera::Camera() : origin(0, 0, 0), screen(), width(), height()
 {
 }
 
-Raytracer::Camera::Camera(const Math::Point3D origin, const Math::Rectangle3D screen) :
-    origin(origin), screen(screen)
+Raytracer::Camera::Camera(const Math::Point3D origin, const Math::Rectangle3D screen,
+    const std::size_t width, const std::size_t height) :
+    origin(origin), screen(screen), width(width), height(height)
 {
 }
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -10,7 +10,7 @@
 #include <map>
 #include <memory>
 
-Raytracer::Config::Config(const std::string fileName) : _fileName(fileName), _config(), _primitiveLoaders()
+Raytracer::Config::Config(const std::string fileName) : _fileName(fileName), _config(), _loaders()
 {
     _config.readFile(_fileName);
     _root = _config.getRoot();
@@ -110,18 +110,18 @@ std::vector<std::shared_ptr<Raytracer::IPrimitive>> Raytracer::Config::parsePrim
 
             // TODO: All of this will probably get replaced by a factory.
             const std::string libName = "./plugins/raytracer_primitive_sphere.so";
-            std::optional<std::shared_ptr<DLLoader<IPrimitive>>> loader;
+            std::optional<std::shared_ptr<DLLoader>> loader;
 
-            auto loaderLocation = _primitiveLoaders.find(libName);
-            if (loaderLocation != _primitiveLoaders.end()) {
+            auto loaderLocation = _loaders.find(libName);
+            if (loaderLocation != _loaders.end()) {
                 loader = loaderLocation->second;
             } else {
-                loader = std::make_shared<DLLoader<IPrimitive>>(libName);
-                _primitiveLoaders.insert({libName, loader.value()});
+                loader = std::make_shared<DLLoader>(libName);
+                _loaders.insert({libName, loader.value()});
             }
 
             primitives.push_back(
-                loader.value()->getInstance(std::string(Utils::primitiveEntrypoint), options)
+                loader.value()->getInstance<IPrimitive>(std::string(Utils::primitiveEntrypoint), options)
             );
         }
 
@@ -160,18 +160,18 @@ std::vector<std::shared_ptr<Raytracer::ILight>> Raytracer::Config::parseLights()
             };
 
             const std::string libName = "./plugins/raytracer_light_point.so";
-            std::optional<std::shared_ptr<DLLoader<ILight>>> loader;
+            std::optional<std::shared_ptr<DLLoader>> loader;
 
-            auto loaderLocation = _lightLoaders.find(libName);
-            if (loaderLocation != _lightLoaders.end()) {
+            auto loaderLocation = _loaders.find(libName);
+            if (loaderLocation != _loaders.end()) {
                 loader = loaderLocation->second;
             } else {
-                loader = std::make_shared<DLLoader<ILight>>(libName);
-                _lightLoaders.insert({libName, loader.value()});
+                loader = std::make_shared<DLLoader>(libName);
+                _loaders.insert({libName, loader.value()});
             }
 
             lights.push_back(
-                loader.value()->getInstance(std::string(Utils::lightEntrypoint), options)
+                loader.value()->getInstance<ILight>(std::string(Utils::lightEntrypoint), options)
             );
         }
         return lights;

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -1,16 +1,13 @@
 #include "Config.hpp"
 #include "Camera.hpp"
 #include "Color.hpp"
-#include "DLLoader.hpp"
 #include "Exception.hpp"
 #include "lights/ILight.hpp"
 #include "primitives/IPrimitive.hpp"
-#include "Utils.hpp"
 #include <libconfig.h++>
-#include <map>
 #include <memory>
 
-Raytracer::Config::Config(const std::string fileName) : _fileName(fileName), _config(), _loaders()
+Raytracer::Config::Config(const std::string fileName) : _fileName(fileName), _config(), _factory()
 {
     _config.readFile(_fileName);
     _root = _config.getRoot();
@@ -108,20 +105,8 @@ std::vector<std::shared_ptr<Raytracer::IPrimitive>> Raytracer::Config::parsePrim
                 static_cast<double>(r)
             };
 
-            // TODO: All of this will probably get replaced by a factory.
-            const std::string libName = "./plugins/raytracer_primitive_sphere.so";
-            std::optional<std::shared_ptr<DLLoader>> loader;
-
-            auto loaderLocation = _loaders.find(libName);
-            if (loaderLocation != _loaders.end()) {
-                loader = loaderLocation->second;
-            } else {
-                loader = std::make_shared<DLLoader>(libName);
-                _loaders.insert({libName, loader.value()});
-            }
-
             primitives.push_back(
-                loader.value()->getInstance<IPrimitive>(std::string(Utils::primitiveEntrypoint), options)
+                _factory.createPrimitive("sphere", options)
             );
         }
 
@@ -159,19 +144,8 @@ std::vector<std::shared_ptr<Raytracer::ILight>> Raytracer::Config::parseLights()
                 .color = Color(),
             };
 
-            const std::string libName = "./plugins/raytracer_light_point.so";
-            std::optional<std::shared_ptr<DLLoader>> loader;
-
-            auto loaderLocation = _loaders.find(libName);
-            if (loaderLocation != _loaders.end()) {
-                loader = loaderLocation->second;
-            } else {
-                loader = std::make_shared<DLLoader>(libName);
-                _loaders.insert({libName, loader.value()});
-            }
-
             lights.push_back(
-                loader.value()->getInstance<ILight>(std::string(Utils::lightEntrypoint), options)
+                _factory.createLight("point", options)
             );
         }
         return lights;

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -1,0 +1,181 @@
+#include "Config.hpp"
+#include "Camera.hpp"
+#include "Color.hpp"
+#include "DLLoader.hpp"
+#include "Exception.hpp"
+#include "lights/ILight.hpp"
+#include "primitives/IPrimitive.hpp"
+#include "Utils.hpp"
+#include <libconfig.h++>
+#include <map>
+#include <memory>
+
+Raytracer::Config::Config(const std::string fileName) : _fileName(fileName), _config(), _primitiveLoaders()
+{
+    _config.readFile(_fileName);
+    _root = _config.getRoot();
+}
+
+Raytracer::Camera Raytracer::Config::parseCamera() const
+{
+    try {
+        const libconfig::Setting &camera = _root->get()["camera"];
+
+        int x = 0;
+        int y = 0;
+        int z = 0;
+        unsigned int width;
+        unsigned int height;
+        double fov = 0.0;
+
+        if (!(
+            camera["position"].lookupValue("x", x) &&
+            camera["position"].lookupValue("y", y) &&
+            camera["position"].lookupValue("z", z) &&
+            camera["resolution"].lookupValue("width", width) &&
+            camera["resolution"].lookupValue("height", height) &&
+            camera.lookupValue("fieldOfView", fov)
+        )) {
+            throw Exception("Invalid camera parameter");
+        }
+
+        Math::Point3D cameraOrigin(x, y, z);
+
+        return Camera(
+            cameraOrigin,
+            Math::Rectangle3D(width, height, fov, cameraOrigin),
+            width,
+            height
+        );
+    } catch (const std::exception &e) {
+        throw Raytracer::Exception("Wrong or missing camera parameter");
+    }
+}
+
+Raytracer::Color Raytracer::Config::parseColor(const libconfig::Setting &setting) const
+{
+    unsigned int colorR;
+    unsigned int colorG;
+    unsigned int colorB;
+
+    if (!(
+        setting["color"].lookupValue("r", colorR) &&
+        setting["color"].lookupValue("g", colorG) &&
+        setting["color"].lookupValue("b", colorB)
+    )) {
+        throw Exception("Invalid color parameter");
+    }
+
+    if (colorR > 255 || colorG > 255 || colorB > 255)
+        throw Exception("Color parameter exceeds 255");
+
+    return {
+        .r = static_cast<unsigned char>(colorR),
+        .g = static_cast<unsigned char>(colorG),
+        .b = static_cast<unsigned char>(colorB),
+    };
+}
+
+std::vector<std::shared_ptr<Raytracer::IPrimitive>> Raytracer::Config::parsePrimitives()
+{
+    std::vector<std::shared_ptr<Raytracer::IPrimitive>> primitives;
+
+    try {
+        const libconfig::Setting &spheres = _root->get()["primitives"]["spheres"];
+        int count = spheres.getLength();
+
+        for (int i = 0; i < count; i++) {
+            const libconfig::Setting &sphere = spheres[i];
+            long long x = 0;
+            long long y = 0;
+            long long z = 0;
+            long long r = 0;
+
+            if (!(
+                sphere.lookupValue("x", x) &&
+                sphere.lookupValue("y", y) &&
+                sphere.lookupValue("z", z) &&
+                sphere.lookupValue("r", r)
+            )) {
+                throw Exception("Invalid sphere parameter");
+            }
+
+            Color color = parseColor(sphere);
+
+            PrimitiveOptions options = {
+                Math::Point3D(x, y, z),
+                color,
+                static_cast<double>(r)
+            };
+
+            // TODO: All of this will probably get replaced by a factory.
+            const std::string libName = "./plugins/raytracer_primitive_sphere.so";
+            std::optional<std::shared_ptr<DLLoader<IPrimitive>>> loader;
+
+            auto loaderLocation = _primitiveLoaders.find(libName);
+            if (loaderLocation != _primitiveLoaders.end()) {
+                loader = loaderLocation->second;
+            } else {
+                loader = std::make_shared<DLLoader<IPrimitive>>(libName);
+                _primitiveLoaders.insert({libName, loader.value()});
+            }
+
+            primitives.push_back(
+                loader.value()->getInstance(std::string(Utils::primitiveEntrypoint), options)
+            );
+        }
+
+        return primitives;
+    } catch (const std::exception &e) {
+        throw Raytracer::Exception("Wrong primitives configuration");
+    }
+}
+
+std::vector<std::shared_ptr<Raytracer::ILight>> Raytracer::Config::parseLights()
+{
+    std::vector<std::shared_ptr<Raytracer::ILight>> lights;
+
+    // TODO: once again, remove hardcode here
+    try {
+        const libconfig::Setting &pointLights = _root->get()["lights"]["point"];
+        int count = pointLights.getLength();
+
+        for (int i = 0; i < count; i++) {
+            const libconfig::Setting &light = pointLights[i];
+            long long x = 0;
+            long long y = 0;
+            long long z = 0;
+
+            if (!(
+                light.lookupValue("x", x) &&
+                light.lookupValue("y", y) &&
+                light.lookupValue("z", z)
+            )) {
+                throw std::exception();
+            }
+
+            LightOptions options = {
+                .position = Math::Point3D(x, y, z),
+                .color = Color(),
+            };
+
+            const std::string libName = "./plugins/raytracer_light_point.so";
+            std::optional<std::shared_ptr<DLLoader<ILight>>> loader;
+
+            auto loaderLocation = _lightLoaders.find(libName);
+            if (loaderLocation != _lightLoaders.end()) {
+                loader = loaderLocation->second;
+            } else {
+                loader = std::make_shared<DLLoader<ILight>>(libName);
+                _lightLoaders.insert({libName, loader.value()});
+            }
+
+            lights.push_back(
+                loader.value()->getInstance(std::string(Utils::lightEntrypoint), options)
+            );
+        }
+        return lights;
+    } catch (const std::exception &e) {
+        throw Raytracer::Exception("Wrong light configuration");
+    }
+}

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -73,43 +73,61 @@ Raytracer::Color Raytracer::Config::parseColor(const libconfig::Setting &setting
     };
 }
 
+Raytracer::PrimitiveOptions Raytracer::Config::parsePrimitiveOptions(const libconfig::Setting &setting) const
+{
+    long long x = 0;
+    long long y = 0;
+    long long z = 0;
+    long long r = 0;
+
+    setting.lookupValue("x", x);
+    setting.lookupValue("y", y);
+    setting.lookupValue("z", z);
+    setting.lookupValue("r", r);
+
+    Color color = parseColor(setting);
+
+    return {
+        .center = Math::Point3D(x, y, z),
+        .color = color,
+        .radius = static_cast<double>(r)
+    };
+}
+
+Raytracer::LightOptions Raytracer::Config::parseLightOptions(const libconfig::Setting &setting) const
+{
+    long long x = 0;
+    long long y = 0;
+    long long z = 0;
+
+    setting.lookupValue("x", x);
+    setting.lookupValue("y", y);
+    setting.lookupValue("z", z);
+
+    return {
+        .position = Math::Point3D(x, y, z),
+        .color = Color(),
+    };
+}
+
 std::vector<std::shared_ptr<Raytracer::IPrimitive>> Raytracer::Config::parsePrimitives()
 {
     std::vector<std::shared_ptr<Raytracer::IPrimitive>> primitives;
 
     try {
-        const libconfig::Setting &spheres = _root->get()["primitives"]["spheres"];
-        int count = spheres.getLength();
+        for (const libconfig::Setting &primitiveCategory : _root->get()["primitives"]) {
+            int count = primitiveCategory.getLength();
 
-        for (int i = 0; i < count; i++) {
-            const libconfig::Setting &sphere = spheres[i];
-            long long x = 0;
-            long long y = 0;
-            long long z = 0;
-            long long r = 0;
+            for (int i = 0; i < count; i++) {
+                const libconfig::Setting &primitive = primitiveCategory[i];
 
-            if (!(
-                sphere.lookupValue("x", x) &&
-                sphere.lookupValue("y", y) &&
-                sphere.lookupValue("z", z) &&
-                sphere.lookupValue("r", r)
-            )) {
-                throw Exception("Invalid sphere parameter");
+                const PrimitiveOptions options = parsePrimitiveOptions(primitive);
+
+                primitives.push_back(
+                    _factory.createPrimitive(primitiveCategory.getName(), options)
+                );
             }
-
-            Color color = parseColor(sphere);
-
-            PrimitiveOptions options = {
-                Math::Point3D(x, y, z),
-                color,
-                static_cast<double>(r)
-            };
-
-            primitives.push_back(
-                _factory.createPrimitive("sphere", options)
-            );
         }
-
         return primitives;
     } catch (const std::exception &e) {
         throw Raytracer::Exception("Wrong primitives configuration");
@@ -120,33 +138,19 @@ std::vector<std::shared_ptr<Raytracer::ILight>> Raytracer::Config::parseLights()
 {
     std::vector<std::shared_ptr<Raytracer::ILight>> lights;
 
-    // TODO: once again, remove hardcode here
     try {
-        const libconfig::Setting &pointLights = _root->get()["lights"]["point"];
-        int count = pointLights.getLength();
+        for (const libconfig::Setting &lightCategory : _root->get()["lights"]) {
+            int count = lightCategory.getLength();
 
-        for (int i = 0; i < count; i++) {
-            const libconfig::Setting &light = pointLights[i];
-            long long x = 0;
-            long long y = 0;
-            long long z = 0;
+            for (int i = 0; i < count; i++) {
+                const libconfig::Setting &light = lightCategory[i];
 
-            if (!(
-                light.lookupValue("x", x) &&
-                light.lookupValue("y", y) &&
-                light.lookupValue("z", z)
-            )) {
-                throw std::exception();
+                const LightOptions options = parseLightOptions(light);
+
+                lights.push_back(
+                    _factory.createLight(lightCategory.getName(), options)
+                );
             }
-
-            LightOptions options = {
-                .position = Math::Point3D(x, y, z),
-                .color = Color(),
-            };
-
-            lights.push_back(
-                _factory.createLight("point", options)
-            );
         }
         return lights;
     } catch (const std::exception &e) {

--- a/src/DLLoader.cpp
+++ b/src/DLLoader.cpp
@@ -1,0 +1,41 @@
+#include "DLLoader.hpp"
+#include "Exception.hpp"
+#include <dlfcn.h>
+#include <memory>
+#include <string>
+
+Raytracer::DLLoader::DLLoader(const std::string libraryName) : _libraryName(libraryName), _handle(nullptr)
+{
+    openHandle();
+};
+
+Raytracer::DLLoader::~DLLoader()
+{
+    closeHandle();
+};
+
+void *Raytracer::DLLoader::openHandle()
+{
+    _handle = dlopen(_libraryName.c_str(), RTLD_NOW);
+    if (_handle == nullptr)
+        throw Raytracer::Exception(dlerror());
+    return _handle;
+}
+
+bool Raytracer::DLLoader::symbolExists(const std::string symbol) const
+{
+    if (_handle == nullptr)
+        return false;
+
+    return dlsym(_handle, symbol.c_str()) != nullptr;
+}
+
+void Raytracer::DLLoader::closeHandle()
+{
+    if (_handle == nullptr)
+        return;
+    if (dlclose(_handle) != 0)
+        throw Raytracer::Exception(dlerror());
+
+    _handle = nullptr;
+}

--- a/src/Factory.cpp
+++ b/src/Factory.cpp
@@ -1,0 +1,86 @@
+#include "Factory.hpp"
+#include "Utils.hpp"
+#include "primitives/PrimitiveOptions.hpp"
+#include <algorithm>
+#include <filesystem>
+#include <iostream>
+
+Raytracer::Factory::Factory()
+{
+    registerAllPlugins();
+}
+
+void Raytracer::Factory::registerAllPlugins()
+{
+    for (const std::filesystem::directory_entry &entry : std::filesystem::directory_iterator(Utils::pluginsDir)) {
+        const std::filesystem::path fsPath = entry.path();
+        const std::string libraryPath = fsPath.string();
+        const std::string libraryFilename = fsPath.filename();
+        const std::string libraryOnlyFilename = fsPath.filename().replace_extension();
+
+        char delim = '_';
+        if (std::count(libraryOnlyFilename.begin(), libraryOnlyFilename.end(), delim) != 2) {
+            std::cerr << "Incorrect plugin name: " << libraryOnlyFilename << ". Skipping over it." << std::endl;
+            continue;
+        }
+
+        std::stringstream ss(libraryOnlyFilename);
+        std::string token;
+        PluginConfig config;
+
+        // Ignore the raytracer bit
+        std::getline(ss, token, delim);
+
+        // Category name
+        std::getline(ss, token, delim);
+        config.category = std::string(token);
+
+        // Object name
+        std::getline(ss, token, delim);
+        config.name = std::string(token);
+
+        std::shared_ptr<DLLoader> loader = std::make_shared<DLLoader>(libraryPath);
+
+        _loaders.insert({libraryPath, loader});
+
+        if (loader->symbolExists(std::string(Utils::primitiveEntrypoint))) {
+            _primitives.insert({
+                config,
+                loader->getSymbol<IPrimitive, PrimitiveOptions>(std::string(Utils::primitiveEntrypoint))
+            });
+        } else if (loader->symbolExists(std::string(Utils::lightEntrypoint))) {
+            _lights.insert({
+                config,
+                loader->getSymbol<ILight, LightOptions>(std::string(Utils::lightEntrypoint))
+            });
+        }
+    }
+}
+
+std::shared_ptr<Raytracer::IPrimitive> Raytracer::Factory::createPrimitive(const std::string name, PrimitiveOptions options)
+{
+    try {
+        std::function function = _primitives.at({
+            .category = std::string("primitive"),
+            .name = name
+        });
+
+        return DLLoader::turnFunctionIntoInstance(function, options);
+    } catch (const std::exception &e) {
+        throw Exception("Couldn't find " + name);
+    }
+}
+
+std::shared_ptr<Raytracer::ILight> Raytracer::Factory::createLight(const std::string name, LightOptions options)
+{
+    try {
+        std::function function = _lights.at({
+            .category = std::string("light"),
+            .name = name
+        });
+
+        return DLLoader::turnFunctionIntoInstance(function, options);
+    } catch (const std::exception &e) {
+        throw Exception("Couldn't find " + name);
+    }
+}

--- a/src/Raytracer.cpp
+++ b/src/Raytracer.cpp
@@ -1,6 +1,4 @@
 #include "Color.hpp"
-#include "DLLoader.hpp"
-#include "Exception.hpp"
 #include "Raytracer.hpp"
 #include "Math/Point3D.hpp"
 #include "Math/Vector3D.hpp"
@@ -8,116 +6,15 @@
 #include "lights/ILight.hpp"
 #include "lights/LightOptions.hpp"
 #include "primitives/IPrimitive.hpp"
-#include "primitives/PrimitiveOptions.hpp"
-#include "Utils.hpp"
 #include <algorithm>
 #include <iostream>
 #include <memory>
-#include <optional>
 
 Raytracer::Raytracer::Raytracer(const std::string sceneFile) :
-    _sceneFile(sceneFile), _config(), _width(), _height(), _primitives(), _lights()
+    _sceneFile(sceneFile), _config(_sceneFile)
 {
-    // TODO: all of this should probably be moved to its own class
-    _config.readFile(_sceneFile);
-    const libconfig::Setting &root = _config.getRoot();
-
-    try {
-        const libconfig::Setting &camera = root["camera"];
-
-        int x = 0;
-        int y = 0;
-        int z = 0;
-        double fov = 0.0;
-
-        if (!(
-            camera["position"].lookupValue("x", x) &&
-            camera["position"].lookupValue("y", y) &&
-            camera["position"].lookupValue("z", z) &&
-            camera["resolution"].lookupValue("width", _width) &&
-            camera["resolution"].lookupValue("height", _height) &&
-            camera.lookupValue("fieldOfView", fov)
-        )) {
-            throw Exception("Invalid camera parameter");
-        }
-
-        Math::Point3D cameraOrigin(x, y, z);
-
-        _camera = Camera(
-            cameraOrigin,
-            Math::Rectangle3D(_width, _height, fov, cameraOrigin)
-        );
-    } catch (const std::exception &e) {
-        std::cerr << "Wrong or missing camera parameter" << std::endl;
-        throw e;
-    }
-
-    try {
-        // This is only temporary, to be removed also
-        const libconfig::Setting &spheres = root["primitives"]["spheres"];
-        int count = spheres.getLength();
-
-        for (int i = 0; i < count; i++) {
-            const libconfig::Setting &sphere = spheres[i];
-            long long x = 0;
-            long long y = 0;
-            long long z = 0;
-            long long r = 0;
-
-            if (!(
-                sphere.lookupValue("x", x) &&
-                sphere.lookupValue("y", y) &&
-                sphere.lookupValue("z", z) &&
-                sphere.lookupValue("r", r)
-            )) {
-                throw Exception("Invalid sphere parameter");
-            }
-
-            unsigned int colorR;
-            unsigned int colorG;
-            unsigned int colorB;
-            Color color;
-
-            if (!(
-                sphere["color"].lookupValue("r", colorR) &&
-                sphere["color"].lookupValue("g", colorG) &&
-                sphere["color"].lookupValue("b", colorB)
-            )) {
-                throw Exception("Invalid color parameter");
-            }
-
-            // TODO: verify that color is < 255
-            color = {
-                .r = static_cast<unsigned char>(colorR),
-                .g = static_cast<unsigned char>(colorG),
-                .b = static_cast<unsigned char>(colorB),
-            };
-
-            PrimitiveOptions options = {
-                Math::Point3D(x, y, z),
-                color,
-                static_cast<double>(r)
-            };
-
-            const std::string libName = "./plugins/raytracer_primitive_sphere.so";
-            std::optional<std::shared_ptr<DLLoader<IPrimitive>>> loader;
-
-            auto loaderLocation = _primitiveLoaders.find(libName);
-            if (loaderLocation != _primitiveLoaders.end()) {
-                loader = loaderLocation->second;
-            } else {
-                loader = std::make_shared<DLLoader<IPrimitive>>(libName);
-                _primitiveLoaders.insert({libName, loader.value()});
-            }
-
-            _primitives.push_back(
-                loader.value()->getInstance(std::string(Utils::primitiveEntrypoint), options)
-            );
-        }
-    } catch (const std::exception &e) {
-        std::cerr << "Wrong primitives configuration" << std::endl;
-        throw e;
-    }
+    _camera = _config.parseCamera();
+    _primitives = _config.parsePrimitives();
 
     // To be changed, this is only temporary as this is highly unefficient and only works for sphere collisions
     std::sort(_primitives.begin(), _primitives.end(), [](std::shared_ptr<IPrimitive> &a, std::shared_ptr<IPrimitive> &b)
@@ -125,49 +22,7 @@ Raytracer::Raytracer::Raytracer(const std::string sceneFile) :
         return a->getOptions().center.z > b->getOptions().center.z;
     });
 
-    // TODO: once again, remove hardcode here
-    try {
-        const libconfig::Setting &pointLights = root["lights"]["point"];
-        int count = pointLights.getLength();
-
-        for (int i = 0; i < count; i++) {
-            const libconfig::Setting &light = pointLights[i];
-            long long x = 0;
-            long long y = 0;
-            long long z = 0;
-
-            if (!(
-                light.lookupValue("x", x) &&
-                light.lookupValue("y", y) &&
-                light.lookupValue("z", z)
-            )) {
-                throw std::exception();
-            }
-
-            LightOptions options = {
-                .position = Math::Point3D(x, y, z),
-                .color = Color(),
-            };
-
-            const std::string libName = "./plugins/raytracer_light_point.so";
-            std::optional<std::shared_ptr<DLLoader<ILight>>> loader;
-
-            auto loaderLocation = _lightLoaders.find(libName);
-            if (loaderLocation != _lightLoaders.end()) {
-                loader = loaderLocation->second;
-            } else {
-                loader = std::make_shared<DLLoader<ILight>>(libName);
-                _lightLoaders.insert({libName, loader.value()});
-            }
-
-            _lights.push_back(
-                loader.value()->getInstance(std::string(Utils::lightEntrypoint), options)
-            );
-        }
-    } catch (const std::exception &e) {
-        std::cerr << "Wrong light configuration" << std::endl;
-        throw e;
-    }
+    _lights = _config.parseLights();
 }
 
 
@@ -207,13 +62,13 @@ void Raytracer::Raytracer::handleHit(std::shared_ptr<IPrimitive> &s, HitInfo &hi
 void Raytracer::Raytracer::exportPPM()
 {
     std::cout << "P3" << std::endl;
-    std::cout << _width << " " << _height << std::endl;
+    std::cout << _camera.width << " " << _camera.height << std::endl;
     std::cout << "255" << std::endl;
 
-    for (std::size_t y = 0; y < _height; y++) {
-        for (std::size_t x = 0; x < _width; x++) {
-            double u = static_cast<double>(x) / _width;
-            double v = static_cast<double>(y) / _height;
+    for (std::size_t y = 0; y < _camera.height; y++) {
+        for (std::size_t x = 0; x < _camera.width; x++) {
+            double u = static_cast<double>(x) / _camera.width;
+            double v = static_cast<double>(y) / _camera.height;
             Ray r = _camera.ray(u, v);
 
             bool hasHit = false;


### PR DESCRIPTION
In this PR:
- Remove the current configuration from the Raytracer class into own class
- Make DLLoader more generic by only using templates on some functions
- Introduce the Factory design pattern to help with plugins
- Configuration is now fully modular and matches the plugin name

Addresses #6