### PR TITLE
Plane primitive & Lights refactoring

### DIFF
--- a/include/Math/Vector3D.hpp
+++ b/include/Math/Vector3D.hpp
@@ -16,8 +16,8 @@ namespace Raytracer {
                 double y;
                 double z;
 
-                double length();
-                double dot(Vector3D &vector);
+                double length() const;
+                double dot(const Vector3D &vector) const;
 
 
 

--- a/include/Raytracer.hpp
+++ b/include/Raytracer.hpp
@@ -4,12 +4,18 @@
 #include "Config.hpp"
 #include "lights/ILight.hpp"
 #include "primitives/IPrimitive.hpp"
+#include <cstddef>
 #include <libconfig.h++>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
 namespace Raytracer {
+    struct Pixel {
+        Color color;
+        double multiplier;
+    };
     class Raytracer {
         public:
             Raytracer() = delete;
@@ -20,10 +26,10 @@ namespace Raytracer {
         private:
             const std::string _sceneFile;
             Config _config;
-
+            double _maxIluminance;
             Camera _camera;
-            void handleHit(std::shared_ptr<IPrimitive> &s, HitInfo &hit, Color &color);
-
+            Pixel handleHit(std::shared_ptr<IPrimitive> &s, HitInfo &hit, Color &color);
+            std::vector<Pixel> _pixels;
             std::vector<std::shared_ptr<IPrimitive>> _primitives;
             std::vector<std::shared_ptr<ILight>> _lights;
     };

--- a/include/Raytracer.hpp
+++ b/include/Raytracer.hpp
@@ -4,9 +4,7 @@
 #include "Config.hpp"
 #include "lights/ILight.hpp"
 #include "primitives/IPrimitive.hpp"
-#include <cstddef>
 #include <libconfig.h++>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/include/Raytracer.hpp
+++ b/include/Raytracer.hpp
@@ -24,7 +24,7 @@ namespace Raytracer {
         private:
             const std::string _sceneFile;
             Config _config;
-            double _maxIluminance;
+            double _maxilluminance;
             Camera _camera;
             Pixel handleHit(std::shared_ptr<IPrimitive> &s, HitInfo &hit, Color &color);
             std::vector<Pixel> _pixels;

--- a/include/primitives/IPrimitive.hpp
+++ b/include/primitives/IPrimitive.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Math/Point3D.hpp"
-#include "Color.hpp"
 #include "Math/Point3D.hpp"
 #include "Ray.hpp"
 #include "HitInfo.hpp"

--- a/include/primitives/Plane.hpp
+++ b/include/primitives/Plane.hpp
@@ -9,10 +9,10 @@
 #include "primitives/PrimitiveOptions.hpp"
 
 namespace Raytracer {
-    class Sphere : public APrimitive {
+    class Plane : public APrimitive {
         public:
-            Sphere(PrimitiveOptions options);
-            ~Sphere() = default;
+            Plane(PrimitiveOptions options);
+            ~Plane() = default;
 
             HitInfo hits(Ray &ray) override;
             Math::Vector3D getNormal(const Math::Point3D) const override;

--- a/include/primitives/PrimitiveOptions.hpp
+++ b/include/primitives/PrimitiveOptions.hpp
@@ -2,13 +2,14 @@
 
 #include "Math/Point3D.hpp"
 #include "Color.hpp"
+#include "Math/Vector3D.hpp"
 
 namespace Raytracer {
     struct PrimitiveOptions {
         // Globally used
         const Math::Point3D center;
         Color color;
-
+        
         // Sphere
         double radius;
     };

--- a/include/primitives/PrimitiveOptions.hpp
+++ b/include/primitives/PrimitiveOptions.hpp
@@ -2,15 +2,24 @@
 
 #include "Math/Point3D.hpp"
 #include "Color.hpp"
-#include "Math/Vector3D.hpp"
+#include <string>
 
 namespace Raytracer {
+    enum class PlaneAxis {
+        None,
+        X,
+        Y,
+        Z
+    };
     struct PrimitiveOptions {
         // Globally used
         const Math::Point3D center;
         Color color;
-        
+
         // Sphere
         double radius;
+        // Plane
+        PlaneAxis axis;
+        long long position;
     };
 }

--- a/scenes/plane_sphere_3_lights.cfg
+++ b/scenes/plane_sphere_3_lights.cfg
@@ -1,0 +1,27 @@
+camera:
+{
+    resolution = { width = 1000; height = 1000; };
+    position = { x = 0; y = 0; z = 0; };
+    fieldOfView = 72.0;
+};
+
+primitives:
+{
+    sphere = (
+        { x = 0; y = -10; z = -225; r = 50; color = { r = 0; g = 255; b = 0; }; },
+        { x = -50; y = -20; z = -150; r = 10; color = { r = 255; g = 255; b = 255; }; },
+    );
+
+    plane = (
+        { axis = "Y"; position = -30; color = { r = 255; g = 255; b = 64; }; }
+    );
+};
+
+lights:
+{
+    point = (
+        { x = 200; y = 200; z = -200; },
+        { x = 0; y = 0; z = 0; },
+        { x = 400; y = 700; z = -1000; }
+    );
+};

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -17,7 +17,7 @@ Raytracer::Camera::Camera(const Math::Point3D origin, const Math::Rectangle3D sc
 Raytracer::Ray Raytracer::Camera::ray(double u, double v)
 {
     Math::Point3D point = screen.pointAt(u, v);
-    Math::Vector3D direction = point - origin;
+    Math::Vector3D direction = origin - point;
 
     return Raytracer::Ray(origin, direction);
 }

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -4,6 +4,7 @@
 #include "Exception.hpp"
 #include "lights/ILight.hpp"
 #include "primitives/IPrimitive.hpp"
+#include "primitives/PrimitiveOptions.hpp"
 #include <libconfig.h++>
 #include <memory>
 
@@ -80,18 +81,36 @@ Raytracer::PrimitiveOptions Raytracer::Config::parsePrimitiveOptions(const libco
     long long y = 0;
     long long z = 0;
     long long r = 0;
+    std::string axisStr;
+    long long position;
 
     setting.lookupValue("x", x);
     setting.lookupValue("y", y);
     setting.lookupValue("z", z);
     setting.lookupValue("r", r);
+    setting.lookupValue("axis", axisStr);
+    setting.lookupValue("position", position);
+
+    PlaneAxis axis = PlaneAxis::None;
+    if (!axisStr.empty()) {
+        if (axisStr == "X" || axisStr == "x")
+            axis = PlaneAxis::X;
+        else if (axisStr == "Y" || axisStr == "y")
+            axis = PlaneAxis::Y;
+        else if (axisStr == "Z" || axisStr == "z")
+            axis = PlaneAxis::Z;
+        else
+            throw Raytracer::Exception("Wrong plane direction");
+    }
 
     Color color = parseColor(setting);
 
     return {
         .center = Math::Point3D(x, y, z),
         .color = color,
-        .radius = static_cast<double>(r)
+        .radius = static_cast<double>(r),
+        .axis = axis,
+        .position = position,
     };
 }
 

--- a/src/Math/Point3D.cpp
+++ b/src/Math/Point3D.cpp
@@ -12,7 +12,7 @@ Raytracer::Math::Point3D Raytracer::Math::Point3D::operator+(const Point3D &poin
 
 Raytracer::Math::Vector3D Raytracer::Math::Point3D::operator-(const Point3D &point) const
 {
-    return Raytracer::Math::Vector3D(x - point.x, y - point.y, z - point.z);
+    return Raytracer::Math::Vector3D(point.x - x, point.y - y, point.z - z);
 }
 
 Raytracer::Math::Point3D Raytracer::Math::Point3D::operator+(const Vector3D &vec) const

--- a/src/Math/Vector3D.cpp
+++ b/src/Math/Vector3D.cpp
@@ -12,12 +12,12 @@ Raytracer::Math::Vector3D::Vector3D(const Matrix3x1 &matrix) : x(matrix.get(0)),
 }
 
 
-double Raytracer::Math::Vector3D::length()
+double Raytracer::Math::Vector3D::length() const
 {
     return std::sqrt(std::pow(x, 2) + std::pow(y, 2) + std::pow(z, 2));
 }
 
-double Raytracer::Math::Vector3D::dot(Vector3D &vector)
+double Raytracer::Math::Vector3D::dot(const Vector3D &vector) const
 {
     return x * vector.x + y * vector.y + z * vector.z;
 }

--- a/src/Math/Vector3D.cpp
+++ b/src/Math/Vector3D.cpp
@@ -124,6 +124,6 @@ Raytracer::Math::Vector3D Raytracer::Math::Vector3D::rotateZ(double degree) cons
 double Raytracer::Math::Vector3D::cosine(Vector3D &normal)
 {
     double value = this->dot(normal) / (this->length() * normal.length());
-    value = std::max(0.0, value);
+    // value = std::max(0.0, value); pas nécéssairement utile
     return value;
 }

--- a/src/Math/Vector3D.cpp
+++ b/src/Math/Vector3D.cpp
@@ -100,7 +100,6 @@ Raytracer::Math::Vector3D Raytracer::Math::Vector3D::operator=(const Matrix3x1 &
     return *this;
 }
 
-
 // https://math.libretexts.org/Bookshelves/Applied_Mathematics/Mathematics_for_Game_Developers_(Burzynski)/04%3A_Matrices/4.06%3A_Rotation_Matrices_in_3-Dimensions
 // https://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions
 Raytracer::Math::Vector3D Raytracer::Math::Vector3D::rotateX(double degree) const
@@ -124,6 +123,5 @@ Raytracer::Math::Vector3D Raytracer::Math::Vector3D::rotateZ(double degree) cons
 double Raytracer::Math::Vector3D::cosine(Vector3D &normal)
 {
     double value = this->dot(normal) / (this->length() * normal.length());
-    // value = std::max(0.0, value); pas nécéssairement utile
     return value;
 }

--- a/src/Raytracer.cpp
+++ b/src/Raytracer.cpp
@@ -12,7 +12,7 @@
 #include <memory>
 
 Raytracer::Raytracer::Raytracer(const std::string sceneFile) :
-    _sceneFile(sceneFile), _config(_sceneFile), _maxIluminance(1.0), _pixels()
+    _sceneFile(sceneFile), _config(_sceneFile), _maxilluminance(1.0), _pixels()
 {
     _camera = _config.parseCamera();
     _primitives = _config.parsePrimitives();
@@ -55,8 +55,8 @@ Raytracer::Pixel Raytracer::Raytracer::handleHit(std::shared_ptr<IPrimitive> &s,
         }
         multiplier += tmpMultiplier;
     }
-    if (this->_maxIluminance < multiplier)
-        this->_maxIluminance = multiplier;
+    if (this->_maxilluminance < multiplier)
+        this->_maxilluminance = multiplier;
     return Pixel {
         .color = color,
         .multiplier = multiplier,
@@ -95,7 +95,7 @@ void Raytracer::Raytracer::exportPPM()
         }
     }
     for (auto &it: _pixels) {
-        it.multiplier /= this->_maxIluminance;
+        it.multiplier /= this->_maxilluminance;
         it.color = it.color * it.multiplier;
         std::cout << static_cast<unsigned int>(it.color.r) << " " 
         << static_cast<unsigned int>(it.color.g) << " "

--- a/src/Raytracer.cpp
+++ b/src/Raytracer.cpp
@@ -32,10 +32,6 @@ Raytracer::Pixel Raytracer::Raytracer::handleHit(std::shared_ptr<IPrimitive> &s,
     double multiplier = 0.0;
     for (std::shared_ptr<ILight> &light: _lights) {
         Math::Vector3D light_Vector = light->getOptions().position - hit.getHitPos();
-        Math::Vector3D invertedLightVector = hit.getHitPos() - light->getOptions().position;
-        // std::cerr << "lightPos: " << light->getOptions().position.x << " " << light->getOptions().position.y << " " << light->getOptions().position.z << std::endl;
-        // std::cerr << "hitPos: " << hit.getHitPos().x << " " << hit.getHitPos().y << " " << hit.getHitPos().z << std::endl;
-        // std::cerr << "lightVector: " << invertedLightVector.x << " " << invertedLightVector.y << " " << invertedLightVector.z << std::endl;
         Math::Vector3D normal = s->getNormal(hit.getHitPos());
         double tmpMultiplier = light_Vector.cosine(normal);
         if (tmpMultiplier <= 0)
@@ -52,7 +48,7 @@ Raytracer::Pixel Raytracer::Raytracer::handleHit(std::shared_ptr<IPrimitive> &s,
             if (lightToNewObject.length() > light_Vector.length()) {
                 continue;
             }
-            if (light_Vector.dot(lightToNewObject) < 0) // le problème est ICI
+            if (light_Vector.dot(lightToNewObject) < 0) // On calcule la norme pour savoir si les vecteurs sont opposés
                 continue;
             tmpMultiplier = 0.0;
             break;
@@ -101,8 +97,8 @@ void Raytracer::Raytracer::exportPPM()
     for (auto &it: _pixels) {
         it.multiplier /= this->_maxIluminance;
         it.color = it.color * it.multiplier;
-        std::cout   << static_cast<unsigned int>(it.color.r) << " "
-            << static_cast<unsigned int>(it.color.g) << " "
-            << static_cast<unsigned int>(it.color.b) << std::endl;
+        std::cout << static_cast<unsigned int>(it.color.r) << " " 
+        << static_cast<unsigned int>(it.color.g) << " "
+        << static_cast<unsigned int>(it.color.b) << std::endl;
     }
 }

--- a/src/Raytracer.cpp
+++ b/src/Raytracer.cpp
@@ -7,11 +7,13 @@
 #include "lights/LightOptions.hpp"
 #include "primitives/IPrimitive.hpp"
 #include <algorithm>
+#include <cstddef>
 #include <iostream>
 #include <memory>
+#include <utility>
 
 Raytracer::Raytracer::Raytracer(const std::string sceneFile) :
-    _sceneFile(sceneFile), _config(_sceneFile)
+    _sceneFile(sceneFile), _config(_sceneFile), _maxIluminance(1.0), _pixels()
 {
     _camera = _config.parseCamera();
     _primitives = _config.parsePrimitives();
@@ -26,7 +28,7 @@ Raytracer::Raytracer::Raytracer(const std::string sceneFile) :
 }
 
 
-void Raytracer::Raytracer::handleHit(std::shared_ptr<IPrimitive> &s, HitInfo &hit, Color &color)
+Raytracer::Pixel Raytracer::Raytracer::handleHit(std::shared_ptr<IPrimitive> &s, HitInfo &hit, Color &color)
 {
     color = hit.getColor();
     double multiplier = 0.0;
@@ -37,25 +39,29 @@ void Raytracer::Raytracer::handleHit(std::shared_ptr<IPrimitive> &s, HitInfo &hi
         if (tmpMultiplier <= 0)
             continue;
         Ray lightToHit(light->getOptions().position, light_Vector);
-        for (std::shared_ptr<IPrimitive> &tmpSphere: _primitives) {
-            if (tmpSphere.get() == s.get())
+        for (std::shared_ptr<IPrimitive> &tmpPrimitive: _primitives) {
+            if (tmpPrimitive.get() == s.get())
                 continue;
-            HitInfo tmpHitInfo = tmpSphere->hits(lightToHit);
+            HitInfo tmpHitInfo = tmpPrimitive->hits(lightToHit);
             if (!tmpHitInfo.hasHit())
                 continue;
             // on calcule la norme des deux vecteurs ainsi que le produit scalaire pour voir si le nouvel objet obstruct la lumière
             Math::Vector3D lightToNewObject = light->getOptions().position - tmpHitInfo.getHitPos();
             if (lightToNewObject.length() > light_Vector.length())
                 continue;
-            if (lightToNewObject.dot(light_Vector) > 0) // > ou < ?
+            if (lightToNewObject.dot(light_Vector) < 0) // > ou < ?
                 continue;
             tmpMultiplier = 0.0;
             break;
         }
         multiplier += tmpMultiplier;
     }
-    multiplier = std::min(1.0, multiplier);
-    color = color * multiplier;
+    if (this->_maxIluminance < multiplier)
+        this->_maxIluminance = multiplier;
+    return Pixel {
+        .color = color,
+        .multiplier = multiplier,
+    };
 }
 
 void Raytracer::Raytracer::exportPPM()
@@ -70,26 +76,30 @@ void Raytracer::Raytracer::exportPPM()
             double v = static_cast<double>(y) / _camera.height;
             Ray r = _camera.ray(u, v);
 
-            bool hasHit = false;
             Color color;
             double currLen = 0;
+            bool hasHit = false;
             for (std::shared_ptr<IPrimitive> &ptr : _primitives) {
                 HitInfo hit = ptr->hits(r);
                 if (hit.hasHit()) {
                     if (currLen != 0 && currLen < (hit.getHitPos() - r.origin).length())
                         continue;
-                    this->handleHit(ptr, hit, color);
+                    if (hasHit == true)
+                        _pixels.pop_back();
+                    _pixels.push_back(this->handleHit(ptr, hit, color));
                     currLen = (hit.getHitPos() - r.origin).length();
                     hasHit = true;
                 }
             }
-
-            if (hasHit) {
-                std::cout   << static_cast<unsigned int>(color.r) << " "
-                            << static_cast<unsigned int>(color.g) << " "
-                            << static_cast<unsigned int>(color.b) << std::endl;
-            } else
-                std::cout << "0 0 0" << std::endl;
+            if (hasHit == false)
+                _pixels.push_back(Pixel{.color = Color(0,0,0), .multiplier = 0});
         }
+    }
+    for (auto &it: _pixels) {
+        it.multiplier /= this->_maxIluminance;
+        it.color = it.color * it.multiplier;
+        std::cout   << static_cast<unsigned int>(it.color.r) << " "
+            << static_cast<unsigned int>(it.color.g) << " "
+            << static_cast<unsigned int>(it.color.b) << std::endl;
     }
 }

--- a/src/Raytracer.cpp
+++ b/src/Raytracer.cpp
@@ -52,7 +52,7 @@ void Raytracer::Raytracer::handleHit(std::shared_ptr<IPrimitive> &s, HitInfo &hi
             tmpMultiplier = 0.0;
             break;
         }
-        multiplier = std::max(multiplier, tmpMultiplier);
+        multiplier += tmpMultiplier;
     }
 
     multiplier = std::min(1.0, multiplier);
@@ -73,12 +73,15 @@ void Raytracer::Raytracer::exportPPM()
 
             bool hasHit = false;
             Color color;
+            double currLen = 0;
             for (std::shared_ptr<IPrimitive> &ptr : _primitives) {
                 HitInfo hit = ptr->hits(r);
                 if (hit.hasHit()) {
+                    if (currLen != 0 && currLen < (hit.getHitPos() - r.origin).length())
+                        continue;
                     this->handleHit(ptr, hit, color);
+                    currLen = (hit.getHitPos() - r.origin).length();
                     hasHit = true;
-                    break;
                 }
             }
 

--- a/src/Raytracer.cpp
+++ b/src/Raytracer.cpp
@@ -12,11 +12,11 @@
 #include <memory>
 
 Raytracer::Raytracer::Raytracer(const std::string sceneFile) :
-    _sceneFile(sceneFile), _config(_sceneFile), _maxilluminance(1.0), _pixels()
+    _sceneFile(sceneFile), _config(_sceneFile), _maxilluminance(1.0)
 {
     _camera = _config.parseCamera();
     _primitives = _config.parsePrimitives();
-
+    _pixels.reserve(_camera.width * _camera.height);
     // To be changed, this is only temporary as this is highly unefficient and only works for sphere collisions
     std::sort(_primitives.begin(), _primitives.end(), [](std::shared_ptr<IPrimitive> &a, std::shared_ptr<IPrimitive> &b)
     {

--- a/src/Raytracer.cpp
+++ b/src/Raytracer.cpp
@@ -10,7 +10,6 @@
 #include <cstddef>
 #include <iostream>
 #include <memory>
-#include <utility>
 
 Raytracer::Raytracer::Raytracer(const std::string sceneFile) :
     _sceneFile(sceneFile), _config(_sceneFile), _maxIluminance(1.0), _pixels()
@@ -27,13 +26,16 @@ Raytracer::Raytracer::Raytracer(const std::string sceneFile) :
     _lights = _config.parseLights();
 }
 
-
 Raytracer::Pixel Raytracer::Raytracer::handleHit(std::shared_ptr<IPrimitive> &s, HitInfo &hit, Color &color)
 {
     color = hit.getColor();
     double multiplier = 0.0;
     for (std::shared_ptr<ILight> &light: _lights) {
         Math::Vector3D light_Vector = light->getOptions().position - hit.getHitPos();
+        Math::Vector3D invertedLightVector = hit.getHitPos() - light->getOptions().position;
+        // std::cerr << "lightPos: " << light->getOptions().position.x << " " << light->getOptions().position.y << " " << light->getOptions().position.z << std::endl;
+        // std::cerr << "hitPos: " << hit.getHitPos().x << " " << hit.getHitPos().y << " " << hit.getHitPos().z << std::endl;
+        // std::cerr << "lightVector: " << invertedLightVector.x << " " << invertedLightVector.y << " " << invertedLightVector.z << std::endl;
         Math::Vector3D normal = s->getNormal(hit.getHitPos());
         double tmpMultiplier = light_Vector.cosine(normal);
         if (tmpMultiplier <= 0)
@@ -47,9 +49,10 @@ Raytracer::Pixel Raytracer::Raytracer::handleHit(std::shared_ptr<IPrimitive> &s,
                 continue;
             // on calcule la norme des deux vecteurs ainsi que le produit scalaire pour voir si le nouvel objet obstruct la lumière
             Math::Vector3D lightToNewObject = light->getOptions().position - tmpHitInfo.getHitPos();
-            if (lightToNewObject.length() > light_Vector.length())
+            if (lightToNewObject.length() > light_Vector.length()) {
                 continue;
-            if (lightToNewObject.dot(light_Vector) < 0) // > ou < ?
+            }
+            if (light_Vector.dot(lightToNewObject) < 0) // le problème est ICI
                 continue;
             tmpMultiplier = 0.0;
             break;

--- a/src/Raytracer.cpp
+++ b/src/Raytracer.cpp
@@ -47,14 +47,13 @@ void Raytracer::Raytracer::handleHit(std::shared_ptr<IPrimitive> &s, HitInfo &hi
             Math::Vector3D lightToNewObject = light->getOptions().position - tmpHitInfo.getHitPos();
             if (lightToNewObject.length() > light_Vector.length())
                 continue;
-            if (lightToNewObject.dot(light_Vector) > 0)
+            if (lightToNewObject.dot(light_Vector) > 0) // > ou < ?
                 continue;
             tmpMultiplier = 0.0;
             break;
         }
         multiplier += tmpMultiplier;
     }
-
     multiplier = std::min(1.0, multiplier);
     color = color * multiplier;
 }

--- a/src/primitives/Makefile
+++ b/src/primitives/Makefile
@@ -7,17 +7,27 @@ SPHERE_SRC	:=	$(COMMON_SRC) \
 SPHERE_OBJ	:=	$(SPHERE_SRC:.cpp=.o)
 SPHERE_BIN	:=	$(PLUGINS_DIR)/raytracer_primitive_sphere.so
 
+
+PLANE_SRC	:=	$(COMMON_SRC) \
+				Plane.cpp
+PLANE_OBJ	:=	$(PLANE_SRC:.cpp=.o)
+PLANE_BIN	:=	$(PLUGINS_DIR)/raytracer_primitive_plane.so
+
 include $(BASE_DIR)/common.mk
 
-all:	$(SPHERE_BIN)
+all:	$(SPHERE_BIN) $(PLANE_BIN)
 
 $(SPHERE_BIN):	$(SPHERE_OBJ)
 
+$(PLANE_BIN): $(PLANE_OBJ)
+
 clean:
 	$(RM) $(SPHERE_OBJ)
+	$(RM) $(PLANE_OBJ)
 
 fclean:	clean
 	$(RM) $(SPHERE_BIN)
+	$(RM) $(PLANE_OBJ)
 
 re:	fclean all
 

--- a/src/primitives/Plane.cpp
+++ b/src/primitives/Plane.cpp
@@ -13,10 +13,6 @@ Raytracer::Plane::Plane(Raytracer::PrimitiveOptions options) : APrimitive(option
 
 Raytracer::HitInfo Raytracer::Plane::hits(Raytracer::Ray &ray)
 {
-    if (ray.direction.dot(this->getNormal(Math::Point3D(0,0,0))) == 0) {
-        return HitInfo(false);
-    }
-
     double k_vec = 0.0;
     // std::cerr <<"x, y, z: " << this->_options.center.x << " " << this->_options.center.y << " " << this->_options.center.z << std::endl;
     if (_options.axis == PlaneAxis::X && ray.direction.x != 0) {
@@ -38,11 +34,11 @@ Raytracer::Math::Vector3D Raytracer::Plane::getNormal(const Math::Point3D point)
 {
     Math::Vector3D normal;
     if (this->_options.axis == PlaneAxis::X)
-        normal = Math::Vector3D(1, 0, 0);
+        normal = Math::Vector3D(-1, 0, 0);
     else if (this->_options.axis == PlaneAxis::Y)
-        normal = Math::Vector3D(0, 1, 0);
+        normal = Math::Vector3D(0, -1, 0);
     else if (this->_options.axis == PlaneAxis::Z)
-        normal = Math::Vector3D(0, 0, 1);
+        normal = Math::Vector3D(0, 0, -1);
     else
         normal = Math::Vector3D(0,0,0);
     return normal;

--- a/src/primitives/Plane.cpp
+++ b/src/primitives/Plane.cpp
@@ -19,36 +19,33 @@ Raytracer::HitInfo Raytracer::Plane::hits(Raytracer::Ray &ray)
 
     double k_vec = 0.0;
     // std::cerr <<"x, y, z: " << this->_options.center.x << " " << this->_options.center.y << " " << this->_options.center.z << std::endl;
-    if (this->_options.center.x != 0 && ray.direction.x != 0)
-        k_vec = (this->_options.center.x - ray.origin.x) / ray.direction.x;
-    else if (this->_options.center.y != 0 && ray.direction.y != 0)
-        k_vec = (this->_options.center.y - ray.origin.y) / ray.direction.y;
-    else if (this->_options.center.z != 0 && ray.direction.z != 0)
-        k_vec = (this->_options.center.z - ray.origin.z) / ray.direction.z;
-    else 
+    if (_options.axis == PlaneAxis::X && ray.direction.x != 0) {
+        k_vec = (this->_options.position - ray.origin.x) / ray.direction.x;
+    } else if (_options.axis == PlaneAxis::Y && ray.direction.y != 0) {
+        k_vec = (this->_options.position - ray.origin.y) / ray.direction.y;
+    } else if (_options.axis == PlaneAxis::Z && ray.direction.z != 0) {
+        k_vec = (this->_options.position - ray.origin.z) / ray.direction.z;
+    } else
         return HitInfo(false);
-    if (k_vec < 0)
+    if (k_vec <= 0)
         return HitInfo(false);
     Math::Point3D coincide = ray.origin + (ray.direction * k_vec);
     // std::cerr << "got coincide x, y, z: " << coincide.x << " " << coincide.y << " " << coincide.z << std::endl;
-
     return HitInfo(true, coincide, _options.color);
 }
 
 Raytracer::Math::Vector3D Raytracer::Plane::getNormal(const Math::Point3D point) const
 {
-    // TODO: penser à une manière plus joli de faire ça pcq là je suis geeked sa mère
     Math::Vector3D normal;
-    if (this->_options.center.x != 0)
-        normal = Math::Vector3D(0, 1, 1);
-    else if (this->_options.center.y != 0)
-        normal = Math::Vector3D(1, 0, 1);
-    else if (this->_options.center.z != 0)
-        normal = Math::Vector3D(1, 1, 0);
+    if (this->_options.axis == PlaneAxis::X)
+        normal = Math::Vector3D(1, 0, 0);
+    else if (this->_options.axis == PlaneAxis::Y)
+        normal = Math::Vector3D(0, 1, 0);
+    else if (this->_options.axis == PlaneAxis::Z)
+        normal = Math::Vector3D(0, 0, 1);
     else
         normal = Math::Vector3D(0,0,0);
-    // std::cerr <<"x, y, z: " << normal.x << " " << normal.y << " " << normal.z << std::endl;
-    return normal;    
+    return normal;
 }
 
 extern "C" Raytracer::IPrimitive *primitiveEntrypoint(Raytracer::PrimitiveOptions options)

--- a/src/primitives/Plane.cpp
+++ b/src/primitives/Plane.cpp
@@ -34,14 +34,20 @@ Raytracer::HitInfo Raytracer::Plane::hits(Raytracer::Ray &ray)
 Raytracer::Math::Vector3D Raytracer::Plane::getNormal(const Math::Point3D) const
 {
     Math::Vector3D normal;
-    if (this->_options.axis == PlaneAxis::X)
-        normal = Math::Vector3D(-1, 0, 0);
-    else if (this->_options.axis == PlaneAxis::Y)
-        normal = Math::Vector3D(0, -1, 0);
-    else if (this->_options.axis == PlaneAxis::Z)
-        normal = Math::Vector3D(0, 0, -1);
-    else
-        normal = Math::Vector3D(0,0,0);
+
+    switch (this->_options.axis) {
+        case Raytracer::PlaneAxis::X:
+            normal = Math::Vector3D(-1, 0, 0);
+            break;
+        case Raytracer::PlaneAxis::Y:
+            normal = Math::Vector3D(0, -1, 0);
+            break;
+        case Raytracer::PlaneAxis::Z:
+            normal = Math::Vector3D(0, 0, -1);
+            break;
+        default:
+            normal = Math::Vector3D(0,0,0);
+    }
     return normal;
 }
 

--- a/src/primitives/Plane.cpp
+++ b/src/primitives/Plane.cpp
@@ -20,14 +20,18 @@ Raytracer::HitInfo Raytracer::Plane::hits(Raytracer::Ray &ray)
     double k_vec = 0.0;
     // std::cerr <<"x, y, z: " << this->_options.center.x << " " << this->_options.center.y << " " << this->_options.center.z << std::endl;
     if (this->_options.center.x != 0 && ray.direction.x != 0)
-        k_vec = this->_options.center.x / ray.direction.x;
+        k_vec = (this->_options.center.x - ray.origin.x) / ray.direction.x;
     else if (this->_options.center.y != 0 && ray.direction.y != 0)
-        k_vec = this->_options.center.y / ray.direction.y;
+        k_vec = (this->_options.center.y - ray.origin.y) / ray.direction.y;
     else if (this->_options.center.z != 0 && ray.direction.z != 0)
-        k_vec = this->_options.center.z / ray.direction.z;
+        k_vec = (this->_options.center.z - ray.origin.z) / ray.direction.z;
     else 
         return HitInfo(false);
-    Math::Point3D coincide =  ray.origin + (ray.direction * k_vec);
+    if (k_vec < 0)
+        return HitInfo(false);
+    Math::Point3D coincide = ray.origin + (ray.direction * k_vec);
+    // std::cerr << "got coincide x, y, z: " << coincide.x << " " << coincide.y << " " << coincide.z << std::endl;
+
     return HitInfo(true, coincide, _options.color);
 }
 

--- a/src/primitives/Plane.cpp
+++ b/src/primitives/Plane.cpp
@@ -1,0 +1,53 @@
+#include "HitInfo.hpp"
+#include "Math/Point3D.hpp"
+#include "Math/Vector3D.hpp"
+#include "primitives/Plane.hpp"
+#include "Ray.hpp"
+#include "primitives/APrimitive.hpp"
+#include "primitives/PrimitiveOptions.hpp"
+#include <iostream>
+
+Raytracer::Plane::Plane(Raytracer::PrimitiveOptions options) : APrimitive(options)
+{
+}
+
+Raytracer::HitInfo Raytracer::Plane::hits(Raytracer::Ray &ray)
+{
+    if (ray.direction.dot(this->getNormal(Math::Point3D(0,0,0))) == 0) {
+        return HitInfo(false);
+    }
+
+    double k_vec = 0.0;
+    // std::cerr <<"x, y, z: " << this->_options.center.x << " " << this->_options.center.y << " " << this->_options.center.z << std::endl;
+    if (this->_options.center.x != 0 && ray.direction.x != 0)
+        k_vec = this->_options.center.x / ray.direction.x;
+    else if (this->_options.center.y != 0 && ray.direction.y != 0)
+        k_vec = this->_options.center.y / ray.direction.y;
+    else if (this->_options.center.z != 0 && ray.direction.z != 0)
+        k_vec = this->_options.center.z / ray.direction.z;
+    else 
+        return HitInfo(false);
+    Math::Point3D coincide =  ray.origin + (ray.direction * k_vec);
+    return HitInfo(true, coincide, _options.color);
+}
+
+Raytracer::Math::Vector3D Raytracer::Plane::getNormal(const Math::Point3D point) const
+{
+    // TODO: penser à une manière plus joli de faire ça pcq là je suis geeked sa mère
+    Math::Vector3D normal;
+    if (this->_options.center.x != 0)
+        normal = Math::Vector3D(0, 1, 1);
+    else if (this->_options.center.y != 0)
+        normal = Math::Vector3D(1, 0, 1);
+    else if (this->_options.center.z != 0)
+        normal = Math::Vector3D(1, 1, 0);
+    else
+        normal = Math::Vector3D(0,0,0);
+    // std::cerr <<"x, y, z: " << normal.x << " " << normal.y << " " << normal.z << std::endl;
+    return normal;    
+}
+
+extern "C" Raytracer::IPrimitive *primitiveEntrypoint(Raytracer::PrimitiveOptions options)
+{
+    return new Raytracer::Plane(options);
+}

--- a/src/primitives/Plane.cpp
+++ b/src/primitives/Plane.cpp
@@ -5,7 +5,6 @@
 #include "Ray.hpp"
 #include "primitives/APrimitive.hpp"
 #include "primitives/PrimitiveOptions.hpp"
-#include <iostream>
 
 Raytracer::Plane::Plane(Raytracer::PrimitiveOptions options) : APrimitive(options)
 {
@@ -13,8 +12,11 @@ Raytracer::Plane::Plane(Raytracer::PrimitiveOptions options) : APrimitive(option
 
 Raytracer::HitInfo Raytracer::Plane::hits(Raytracer::Ray &ray)
 {
+    if (ray.direction.dot(this->getNormal(Math::Point3D(0,0,0))) == 0) {
+        return HitInfo(false);
+    }
+
     double k_vec = 0.0;
-    // std::cerr <<"x, y, z: " << this->_options.center.x << " " << this->_options.center.y << " " << this->_options.center.z << std::endl;
     if (_options.axis == PlaneAxis::X && ray.direction.x != 0) {
         k_vec = (this->_options.position - ray.origin.x) / ray.direction.x;
     } else if (_options.axis == PlaneAxis::Y && ray.direction.y != 0) {
@@ -26,11 +28,10 @@ Raytracer::HitInfo Raytracer::Plane::hits(Raytracer::Ray &ray)
     if (k_vec <= 0)
         return HitInfo(false);
     Math::Point3D coincide = ray.origin + (ray.direction * k_vec);
-    // std::cerr << "got coincide x, y, z: " << coincide.x << " " << coincide.y << " " << coincide.z << std::endl;
     return HitInfo(true, coincide, _options.color);
 }
 
-Raytracer::Math::Vector3D Raytracer::Plane::getNormal(const Math::Point3D point) const
+Raytracer::Math::Vector3D Raytracer::Plane::getNormal(const Math::Point3D) const
 {
     Math::Vector3D normal;
     if (this->_options.axis == PlaneAxis::X)

--- a/src/primitives/Sphere.cpp
+++ b/src/primitives/Sphere.cpp
@@ -1,4 +1,3 @@
-#include "Color.hpp"
 #include "Math/Point3D.hpp"
 #include "Math/Vector3D.hpp"
 #include "primitives/Sphere.hpp"

--- a/src/primitives/Sphere.cpp
+++ b/src/primitives/Sphere.cpp
@@ -31,7 +31,7 @@ Raytracer::Sphere::Sphere(Raytracer::PrimitiveOptions options) : APrimitive(opti
 //
 Raytracer::HitInfo Raytracer::Sphere::hits(Raytracer::Ray &ray)
 {
-    Math::Vector3D centerOffset = _options.center - ray.origin;
+    Math::Vector3D centerOffset = ray.origin - _options.center;
     double a = ray.direction.dot(ray.direction);
     double b = 2 * ray.direction.x * centerOffset.x + 2 * ray.direction.y * centerOffset.y + 2 * ray.direction.z * centerOffset.z;
     double c = centerOffset.dot(centerOffset) - std::pow(_options.radius, 2);
@@ -54,7 +54,7 @@ Raytracer::HitInfo Raytracer::Sphere::hits(Raytracer::Ray &ray)
 
 Raytracer::Math::Vector3D Raytracer::Sphere::getNormal(const Math::Point3D point) const
 {
-    return point - _options.center;
+    return point - this->_options.center;
 }
 
 extern "C" Raytracer::IPrimitive *primitiveEntrypoint(Raytracer::PrimitiveOptions options)


### PR DESCRIPTION
Ajout de la primitive "Plan"
Support pour les ombres avec le plan
Fix l'opérateur "-" du Point3D qui pour A-B nous donnait le vecteur AB et pas le vecteur BA

Refacto les lumières et la luminance des plans
Pour ça j'ai du changer un peu la structure du exportPPM() du raytracer où on stock d'abord les couleurs et le multiplicateur de luminance, et on reparcourt ensuite tous les pixels pour les afficher, mais on divise le multiplicateur de chaque pixel par le multiplicateur max

Grâce à ça le rendu avec plusieurs lumières est beaucoup plus clean qu'il ne l'était avant

Related #1 