### PR TITLE
Introduce Transformations (Scale)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ BINARY	:=	raytracer
 
 all:	plugins $(BINARY)
 
-plugins: primitives lights
+plugins: primitives lights transforms
 
 primitives:
 	$(MAKE) -C src/primitives
@@ -62,17 +62,22 @@ primitives:
 lights:
 	$(MAKE) -C src/lights
 
+transforms:
+	$(MAKE) -C src/transforms
+
 $(BINARY):	$(OBJ)
 	$(CXX) -o $(BINARY) $(OBJ) $(LDFLAGS) $(LDLIBS)
 
 clean:
 	$(MAKE) -C src/primitives clean
 	$(MAKE) -C src/lights clean
+	$(MAKE) -C src/transforms clean
 	$(RM) $(OBJ)
 
 fclean:	clean
 	$(MAKE) -C src/primitives fclean
 	$(MAKE) -C src/lights fclean
+	$(MAKE) -C src/transforms fclean
 	$(RM) $(BINARY)
 
 re:	fclean all

--- a/include/Config.hpp
+++ b/include/Config.hpp
@@ -35,5 +35,9 @@ namespace Raytracer {
             PrimitiveOptions parsePrimitiveOptions(const libconfig::Setting &setting) const;
             LightOptions parseLightOptions(const libconfig::Setting &setting) const;
             std::vector<Math::Point3D> parseVertices(const libconfig::Setting &setting) const;
+            std::shared_ptr<ITransform> parseTransform(
+                const libconfig::Setting &setting,
+                std::shared_ptr<ITransform> ptr
+            ) const;
     };
 }

--- a/include/Factory.hpp
+++ b/include/Factory.hpp
@@ -5,6 +5,8 @@
 #include "lights/LightOptions.hpp"
 #include "primitives/IPrimitive.hpp"
 #include "primitives/PrimitiveOptions.hpp"
+#include "transforms/ITransform.hpp"
+#include "transforms/TransformOptions.hpp"
 #include <unordered_map>
 #include <map>
 #include <memory>
@@ -17,8 +19,9 @@ namespace Raytracer {
             ~Factory() = default;
 
             void registerAllPlugins();
-            std::shared_ptr<IPrimitive> createPrimitive(const std::string name, PrimitiveOptions options);
-            std::shared_ptr<ILight> createLight(const std::string name, LightOptions options);
+            std::shared_ptr<IPrimitive> createPrimitive(const std::string name, PrimitiveOptions options) const;
+            std::shared_ptr<ILight> createLight(const std::string name, LightOptions options) const;
+            std::shared_ptr<ITransform> createTransform(const std::string name, TransformOptions options) const;
 
         private:
             struct PluginConfig {
@@ -48,5 +51,6 @@ namespace Raytracer {
             std::map<const std::string, std::shared_ptr<DLLoader>> _loaders;
             std::unordered_map<PluginConfig, std::function<IPrimitive *(PrimitiveOptions)>, PluginConfigHash> _primitives;
             std::unordered_map<PluginConfig, std::function<ILight *(LightOptions)>, PluginConfigHash> _lights;
+            std::unordered_map<PluginConfig, std::function<ITransform *(TransformOptions)>, PluginConfigHash> _transforms;
     };
 }

--- a/include/Utils.hpp
+++ b/include/Utils.hpp
@@ -5,6 +5,7 @@
 namespace Raytracer::Utils {
     constexpr std::string_view primitiveEntrypoint("primitiveEntrypoint");
     constexpr std::string_view lightEntrypoint("lightEntrypoint");
+    constexpr std::string_view transformEntrypoint("transformEntrypoint");
 
     // Related to the binary path of the raytracer.
     constexpr std::string_view pluginsDir("./plugins");

--- a/include/primitives/PrimitiveOptions.hpp
+++ b/include/primitives/PrimitiveOptions.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 namespace Raytracer {
+    class ITransform;
     struct PrimitiveOptions {
         // Globally used
         const Math::Point3D center;

--- a/include/primitives/PrimitiveOptions.hpp
+++ b/include/primitives/PrimitiveOptions.hpp
@@ -3,6 +3,8 @@
 #include "Math/Point3D.hpp"
 #include "Color.hpp"
 #include "Math/Vector3D.hpp"
+#include "transforms/ITransform.hpp"
+#include <memory>
 #include <vector>
 
 namespace Raytracer {
@@ -10,6 +12,7 @@ namespace Raytracer {
         // Globally used
         const Math::Point3D center;
         Color color;
+        std::shared_ptr<ITransform> transform;
 
         // Sphere
         double radius;

--- a/include/transforms/ATransform.hpp
+++ b/include/transforms/ATransform.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Math/Vector3D.hpp"
+#include "primitives/PrimitiveOptions.hpp"
 #include "transforms/ITransform.hpp"
 #include "transforms/TransformOptions.hpp"
 
@@ -13,6 +14,7 @@ namespace Raytracer {
 
             void transformVector(Math::Vector3D &) override;
             void transformPoint(Math::Point3D &) override;
+            void transformPrimitive(PrimitiveOptions &) override;
 
         protected:
             TransformOptions _options;

--- a/include/transforms/ATransform.hpp
+++ b/include/transforms/ATransform.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Math/Vector3D.hpp"
+#include "transforms/ITransform.hpp"
+#include "transforms/TransformOptions.hpp"
+
+namespace Raytracer {
+    class ATransform : public ITransform {
+        public:
+            ATransform() = delete;
+            ATransform(TransformOptions options);
+            ~ATransform() = default;
+
+            void transformVector(Math::Vector3D &) override;
+            void transformPoint(Math::Point3D &) override;
+
+        protected:
+            TransformOptions _options;
+    };
+}

--- a/include/transforms/Default.hpp
+++ b/include/transforms/Default.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "transforms/ATransform.hpp"
+#include "transforms/TransformOptions.hpp"
+
+namespace Raytracer {
+    class Default : public ATransform {
+        public:
+            Default() = delete;
+            Default(TransformOptions);
+            ~Default() = default;
+    };
+}

--- a/include/transforms/ITransform.hpp
+++ b/include/transforms/ITransform.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "Math/Point3D.hpp"
+#include "Math/Vector3D.hpp"
+
+namespace Raytracer {
+    class ITransform {
+        public:
+            virtual ~ITransform() = default;
+
+            virtual void transformVector(Math::Vector3D &) = 0;
+            virtual void transformPoint(Math::Point3D &) = 0;
+    };
+}

--- a/include/transforms/ITransform.hpp
+++ b/include/transforms/ITransform.hpp
@@ -2,13 +2,16 @@
 
 #include "Math/Point3D.hpp"
 #include "Math/Vector3D.hpp"
+#include "primitives/PrimitiveOptions.hpp"
 
 namespace Raytracer {
+    struct PrimitiveOptions;
     class ITransform {
         public:
             virtual ~ITransform() = default;
 
             virtual void transformVector(Math::Vector3D &) = 0;
             virtual void transformPoint(Math::Point3D &) = 0;
+            virtual void transformPrimitive(PrimitiveOptions &) = 0;
     };
 }

--- a/include/transforms/Scale.hpp
+++ b/include/transforms/Scale.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "primitives/PrimitiveOptions.hpp"
+#include "transforms/ATransform.hpp"
+#include "transforms/TransformOptions.hpp"
+
+namespace Raytracer {
+    class Scale : public ATransform {
+        public:
+            Scale() = delete;
+            Scale(TransformOptions options);
+            ~Scale() = default;
+
+            void transformPrimitive(PrimitiveOptions &) override;
+
+        private:
+            void scaleTriangle(std::vector<Math::Point3D> &vertices);
+    };
+}

--- a/include/transforms/TransformOptions.hpp
+++ b/include/transforms/TransformOptions.hpp
@@ -6,7 +6,7 @@
 namespace Raytracer {
     struct TransformOptions {
         std::shared_ptr<ITransform> ptr;
-        // Rotate
-        unsigned int angle;
+        // Scale
+        double multiplier;
     };
 }

--- a/include/transforms/TransformOptions.hpp
+++ b/include/transforms/TransformOptions.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "transforms/ITransform.hpp"
+#include <memory>
+
+namespace Raytracer {
+    struct TransformOptions {
+        std::shared_ptr<ITransform> ptr;
+        // Rotate
+        unsigned int angle;
+    };
+}

--- a/scenes/transform_scale.cfg
+++ b/scenes/transform_scale.cfg
@@ -1,0 +1,56 @@
+camera:
+{
+    resolution = { width = 1000; height = 1000; };
+    position = { x = 0; y = 0; z = 0; };
+    fieldOfView = 72.0;
+};
+
+primitives:
+{
+    plane = (
+        { axis = "Y"; position = -30; color = { r = 64; g = 150; b = 64; }; }
+    );
+
+    sphere = (
+        {
+            x = -50; y = 0; z = -100; r = 10;
+            color = { r = 255; g = 0; b = 0; };
+            transforms = (
+                { type = "scale", multiplier = 2.0 }
+            );
+        }
+    );
+
+    cylinder = (
+        {
+            x = 40; y = 0; z = -100; r = 10;
+            cylinderAxis = { x = 0; y = 1; z = 0; };
+            color = { r = 255; g = 0; b = 0; };
+            transforms = (
+                { type = "scale", multiplier = 2.0 }
+            );
+        }
+    );
+
+    triangle = (
+        {
+            vertices = (
+                { x = 10; y = -40; z = -80; },
+                { x = 0; y = 20; z = -90; },
+                { x = -10; y = -20; z = -100; }
+            )
+            color = { r = 255; g = 0; b = 0; };
+            transforms = (
+                { type = "scale", multiplier = 1.2 }
+            );
+        },
+    )
+};
+
+lights:
+{
+    point = (
+        { x = 0; y = 0; z = 0; },
+        { x = 0; y = -10; z = -120; },
+    );
+};

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -137,15 +137,15 @@ std::shared_ptr<Raytracer::ITransform> Raytracer::Config::parseTransform(
 
     for (const libconfig::Setting &transform : setting["transforms"]) {
         std::string type;
-        unsigned int angle = 0;
+        double multiplier = 0;
 
         if (!transform.lookupValue("type", type))
             throw Exception("Invalid transform type");
-        transform.lookupValue("angle", angle);
+        transform.lookupValue("multiplier", multiplier);
 
         TransformOptions options = {
             .ptr = ptr,
-            .angle = angle,
+            .multiplier = multiplier,
         };
         ptr = _factory.createTransform(type, options);
     }
@@ -196,7 +196,7 @@ Raytracer::PrimitiveOptions Raytracer::Config::parsePrimitiveOptions(const libco
 
     std::vector<Math::Point3D> vertices = parseVertices(setting);
 
-    return {
+    Raytracer::PrimitiveOptions options{
         .center = Math::Point3D(center.x, center.y, center.z),
         .color = color,
         .transform = transform,
@@ -205,6 +205,9 @@ Raytracer::PrimitiveOptions Raytracer::Config::parsePrimitiveOptions(const libco
         .vertices = vertices,
         .cylinderAxis = cylinderAxis
     };
+
+    options.transform->transformPrimitive(options);
+    return options;
 }
 
 Raytracer::LightOptions Raytracer::Config::parseLightOptions(const libconfig::Setting &setting) const

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -7,6 +7,8 @@
 #include "lights/ILight.hpp"
 #include "primitives/IPrimitive.hpp"
 #include "primitives/PrimitiveOptions.hpp"
+#include "transforms/ITransform.hpp"
+#include "transforms/TransformOptions.hpp"
 #include <exception>
 #include <iostream>
 #include <libconfig.h++>
@@ -125,6 +127,31 @@ Raytracer::Math::Vector3D Raytracer::Config::parseCylinderAxis(const libconfig::
     return Math::Vector3D(static_cast<double>(x), static_cast<double>(y), static_cast<double>(z));
 }
 
+std::shared_ptr<Raytracer::ITransform> Raytracer::Config::parseTransform(
+    const libconfig::Setting &setting,
+    std::shared_ptr<ITransform> ptr
+) const
+{
+    if (!setting.exists("transforms"))
+        return ptr;
+
+    for (const libconfig::Setting &transform : setting["transforms"]) {
+        std::string type;
+        unsigned int angle = 0;
+
+        if (!transform.lookupValue("type", type))
+            throw Exception("Invalid transform type");
+        transform.lookupValue("angle", angle);
+
+        TransformOptions options = {
+            .ptr = ptr,
+            .angle = angle,
+        };
+        ptr = _factory.createTransform(type, options);
+    }
+    return ptr;
+}
+
 Raytracer::PrimitiveOptions Raytracer::Config::parsePrimitiveOptions(const libconfig::Setting &setting) const
 {
     long long x = 0;
@@ -140,6 +167,10 @@ Raytracer::PrimitiveOptions Raytracer::Config::parsePrimitiveOptions(const libco
     setting.lookupValue("r", r);
     setting.lookupValue("axis", axisStr);
     setting.lookupValue("position", position);
+
+    TransformOptions transformOptions;
+    std::shared_ptr<ITransform> transform = _factory.createTransform("default", transformOptions);
+    transform = parseTransform(setting, transform);
 
     Math::Vector3D normal;
     Math::Vector3D center = Math::Vector3D(x,y,z);
@@ -168,6 +199,7 @@ Raytracer::PrimitiveOptions Raytracer::Config::parsePrimitiveOptions(const libco
     return {
         .center = Math::Point3D(center.x, center.y, center.z),
         .color = color,
+        .transform = transform,
         .radius = static_cast<double>(r),
         .normal = normal,
         .vertices = vertices,

--- a/src/Factory.cpp
+++ b/src/Factory.cpp
@@ -1,9 +1,12 @@
 #include "Factory.hpp"
 #include "Utils.hpp"
 #include "primitives/PrimitiveOptions.hpp"
+#include "transforms/ITransform.hpp"
+#include "transforms/TransformOptions.hpp"
 #include <algorithm>
 #include <filesystem>
 #include <iostream>
+#include <memory>
 
 Raytracer::Factory::Factory()
 {
@@ -53,11 +56,16 @@ void Raytracer::Factory::registerAllPlugins()
                 config,
                 loader->getSymbol<ILight, LightOptions>(std::string(Utils::lightEntrypoint))
             });
+        } else if (loader->symbolExists(std::string(Utils::transformEntrypoint))) {
+            _transforms.insert({
+                config,
+                loader->getSymbol<ITransform, TransformOptions>(std::string(Utils::transformEntrypoint))
+            });
         }
     }
 }
 
-std::shared_ptr<Raytracer::IPrimitive> Raytracer::Factory::createPrimitive(const std::string name, PrimitiveOptions options)
+std::shared_ptr<Raytracer::IPrimitive> Raytracer::Factory::createPrimitive(const std::string name, PrimitiveOptions options) const
 {
     try {
         std::function function = _primitives.at({
@@ -71,11 +79,25 @@ std::shared_ptr<Raytracer::IPrimitive> Raytracer::Factory::createPrimitive(const
     }
 }
 
-std::shared_ptr<Raytracer::ILight> Raytracer::Factory::createLight(const std::string name, LightOptions options)
+std::shared_ptr<Raytracer::ILight> Raytracer::Factory::createLight(const std::string name, LightOptions options) const
 {
     try {
         std::function function = _lights.at({
             .category = std::string("light"),
+            .name = name
+        });
+
+        return DLLoader::turnFunctionIntoInstance(function, options);
+    } catch (const std::exception &e) {
+        throw Exception("Couldn't find " + name);
+    }
+}
+
+std::shared_ptr<Raytracer::ITransform> Raytracer::Factory::createTransform(const std::string name, TransformOptions options) const
+{
+    try {
+        std::function function = _transforms.at({
+            .category = std::string("transform"),
             .name = name
         });
 

--- a/src/transforms/ATransform.cpp
+++ b/src/transforms/ATransform.cpp
@@ -12,3 +12,7 @@ void Raytracer::ATransform::transformVector(Raytracer::Math::Vector3D &)
 void Raytracer::ATransform::transformPoint(Raytracer::Math::Point3D &)
 {
 }
+
+void Raytracer::ATransform::transformPrimitive(Raytracer::PrimitiveOptions &)
+{
+}

--- a/src/transforms/ATransform.cpp
+++ b/src/transforms/ATransform.cpp
@@ -1,0 +1,14 @@
+#include "transforms/ATransform.hpp"
+#include "transforms/TransformOptions.hpp"
+
+Raytracer::ATransform::ATransform(TransformOptions options) : _options(options)
+{
+}
+
+void Raytracer::ATransform::transformVector(Raytracer::Math::Vector3D &)
+{
+}
+
+void Raytracer::ATransform::transformPoint(Raytracer::Math::Point3D &)
+{
+}

--- a/src/transforms/Default.cpp
+++ b/src/transforms/Default.cpp
@@ -1,0 +1,13 @@
+#include "transforms/Default.hpp"
+#include "transforms/ATransform.hpp"
+#include "transforms/ITransform.hpp"
+#include "transforms/TransformOptions.hpp"
+
+Raytracer::Default::Default(TransformOptions options) : ATransform(options)
+{
+}
+
+extern "C" Raytracer::ITransform *transformEntrypoint(Raytracer::TransformOptions options)
+{
+    return new Raytracer::Default(options);
+}

--- a/src/transforms/Makefile
+++ b/src/transforms/Makefile
@@ -7,17 +7,26 @@ DEFAULT_SRC	:=	$(COMMON_SRC) \
 DEFAULT_OBJ	:=	$(DEFAULT_SRC:.cpp=.o)
 DEFAULT_BIN	:=	$(PLUGINS_DIR)/raytracer_transform_default.so
 
+SCALE_SRC	:=	$(COMMON_SRC) \
+				Scale.cpp
+SCALE_OBJ	:=	$(SCALE_SRC:.cpp=.o)
+SCALE_BIN	:=	$(PLUGINS_DIR)/raytracer_transform_scale.so
+
 include $(BASE_DIR)/common.mk
 
-all:	$(DEFAULT_BIN)
+all:	$(DEFAULT_BIN) $(SCALE_BIN)
 
 $(DEFAULT_BIN):	$(DEFAULT_OBJ)
 
+$(SCALE_BIN):	$(SCALE_OBJ)
+
 clean:
 	$(RM) $(DEFAULT_OBJ)
+	$(RM) $(SCALE_OBJ)
 
 fclean:	clean
 	$(RM) $(DEFAULT_BIN)
+	$(RM) $(SCALE_BIN)
 
 re:	fclean all
 

--- a/src/transforms/Makefile
+++ b/src/transforms/Makefile
@@ -1,0 +1,24 @@
+COMMON_SRC	:=	$(COMMON_SRC) \
+				$(MATH_SRC) \
+				ATransform.cpp
+
+DEFAULT_SRC	:=	$(COMMON_SRC) \
+				Default.cpp
+DEFAULT_OBJ	:=	$(DEFAULT_SRC:.cpp=.o)
+DEFAULT_BIN	:=	$(PLUGINS_DIR)/raytracer_transform_default.so
+
+include $(BASE_DIR)/common.mk
+
+all:	$(DEFAULT_BIN)
+
+$(DEFAULT_BIN):	$(DEFAULT_OBJ)
+
+clean:
+	$(RM) $(DEFAULT_OBJ)
+
+fclean:	clean
+	$(RM) $(DEFAULT_BIN)
+
+re:	fclean all
+
+.PHONY:	all clean fclean re

--- a/src/transforms/Scale.cpp
+++ b/src/transforms/Scale.cpp
@@ -1,0 +1,46 @@
+#include "transforms/Scale.hpp"
+#include "Math/Point3D.hpp"
+#include "transforms/ATransform.hpp"
+#include "transforms/TransformOptions.hpp"
+
+Raytracer::Scale::Scale(Raytracer::TransformOptions options) : ATransform(options)
+{
+}
+
+// https://stackoverflow.com/questions/8591991/algorithm-to-enlarge-scale-inflate-enbiggen-a-triangle
+void Raytracer::Scale::scaleTriangle(std::vector<Math::Point3D> &vertices)
+{
+    if (vertices.size() != 3)
+        return;
+
+    Math::Point3D &first = vertices.at(0);
+    Math::Point3D &second = vertices.at(1);
+    Math::Point3D &third = vertices.at(2);
+
+    Math::Point3D center(
+        (first.x + second.x + third.x) / 3,
+        (first.y + second.y + third.y) / 3,
+        0
+    );
+
+    for (Math::Point3D &vertice : vertices) {
+        vertice.x = center.x + (vertice.x - center.x) * _options.multiplier;
+        vertice.y = center.y + (vertice.y - center.y) * _options.multiplier;
+    }
+}
+
+void Raytracer::Scale::transformPrimitive(Raytracer::PrimitiveOptions &options)
+{
+    _options.ptr->transformPrimitive(options);
+
+    if (_options.multiplier == 0)
+        return;
+
+    options.radius *= _options.multiplier;
+    scaleTriangle(options.vertices);
+}
+
+extern "C" Raytracer::ITransform *transformEntrypoint(Raytracer::TransformOptions options)
+{
+    return new Raytracer::Scale(options);
+}


### PR DESCRIPTION
Only Scale transformation for now

Uses the Decorator design pattern
Closes #6 

Example:

Here is without scaling:
<img width="400" alt="output" src="https://github.com/user-attachments/assets/8eb46e8b-74e2-4bb7-b4db-af7611d48bef" />

With scaling:
<img width="400" alt="output2" src="https://github.com/user-attachments/assets/ce933c89-a6fa-4ece-b6fe-2f59fc32a7ae" />