### PR TITLE
Chessboard (second round)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,12 +75,14 @@ clean:
 	$(MAKE) -C src/primitives clean
 	$(MAKE) -C src/lights clean
 	$(MAKE) -C src/transforms clean
+	$(MAKE) -C src/materials clean
 	$(RM) $(OBJ)
 
 fclean:	clean
 	$(MAKE) -C src/primitives fclean
 	$(MAKE) -C src/lights fclean
 	$(MAKE) -C src/transforms fclean
+	$(MAKE) -C src/materials fclean
 	$(RM) $(BINARY)
 
 re:	fclean all

--- a/include/materials/AMaterial.hpp
+++ b/include/materials/AMaterial.hpp
@@ -11,6 +11,7 @@ namespace Raytracer {
             ~AMaterial() = default;
 
             MaterialOptions getOptions() const override;
+            Color applyMaterial(Color, Math::Point3D) const override;
 
         protected:
             MaterialOptions _options;

--- a/include/materials/Chessboard.hpp
+++ b/include/materials/Chessboard.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "materials/AMaterial.hpp"
+#include "materials/MaterialOptions.hpp"
+
+namespace Raytracer {
+    class Chessboard : public AMaterial {
+        public:
+            Chessboard() = delete;
+            Chessboard(MaterialOptions options);
+            Color applyMaterial(Color, Math::Point3D) const override;
+            ~Chessboard() = default;
+    };
+}

--- a/include/materials/IMaterial.hpp
+++ b/include/materials/IMaterial.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Math/Point3D.hpp"
 #include "materials/MaterialOptions.hpp"
 namespace Raytracer {
     class IMaterial {
@@ -7,5 +8,6 @@ namespace Raytracer {
             virtual ~IMaterial() = default;
 
             virtual MaterialOptions getOptions() const = 0;
+            virtual Color applyMaterial(Color, Math::Point3D) const = 0;
     };
 }

--- a/scenes/chessboard.cfg
+++ b/scenes/chessboard.cfg
@@ -1,0 +1,40 @@
+camera:
+{
+    resolution = { width = 1000; height = 1000; };
+    position = { x = 0; y = 0; z = 0; };
+    fieldOfView = 72.0;
+};
+
+primitives:
+{
+    sphere = (
+        { x = 10; y = 10; z = -300; r = 40; color = { r = 0; g = 255; b = 0; }; material = {name = "chessboard"}},
+    );
+
+    plane = (
+       { axis = "Y"; position = -30; color = { r = 135; g = 135; b = 135; };   material = {name = "chessboard"}},
+    );
+
+    triangle = (
+    {
+        vertices = (
+            { x = -80; y = -20; z = -150; },
+            { x = -50; y = 20; z = -160; },
+            { x = -40; y = -10; z = -170; }
+        )
+        color = { r = 255; g = 255; b = 255; };
+        material = {name = "chessboard"}
+    })
+    cylinder = (
+        { x = 100; y = 0; z = -200; r = 20; cylinderAxis = { x = 0; y = 1; z = 0; }; color = { r = 255; g = 0; b = 0; }; material = {name = "chessboard"}},
+    );
+};
+
+lights:
+{
+    point = (
+        { x = 0; y = 0; z = 0; }
+
+    );
+    ambient = { multiplier = 0.4 };
+};

--- a/src/Raytracer.cpp
+++ b/src/Raytracer.cpp
@@ -169,6 +169,7 @@ Raytracer::Pixel Raytracer::Raytracer::hitIlluminance(std::shared_ptr<IPrimitive
     }
     // multiplier /= _lights.size();
     multiplier = std::min(multiplier, 1.0);
+    color = s->getOptions().material->applyMaterial(color, hit.getHitPos());
     return Pixel(color, multiplier);
 }
 

--- a/src/materials/AMaterial.cpp
+++ b/src/materials/AMaterial.cpp
@@ -1,4 +1,6 @@
 #include "materials/AMaterial.hpp"
+#include "Color.hpp"
+#include "Math/Point3D.hpp"
 #include "materials/MaterialOptions.hpp"
 
 Raytracer::AMaterial::AMaterial(Raytracer::MaterialOptions options) : _options(options)
@@ -8,4 +10,9 @@ Raytracer::AMaterial::AMaterial(Raytracer::MaterialOptions options) : _options(o
 Raytracer::MaterialOptions Raytracer::AMaterial::getOptions() const
 {
     return _options;
+}
+
+Raytracer::Color Raytracer::AMaterial::applyMaterial(Raytracer::Color color, Math::Point3D) const 
+{
+    return color;
 }

--- a/src/materials/Chessboard.cpp
+++ b/src/materials/Chessboard.cpp
@@ -1,0 +1,23 @@
+#include "materials/Chessboard.hpp"
+#include "Color.hpp"
+#include "materials/Chessboard.hpp"
+#include "materials/AMaterial.hpp"
+#include "materials/IMaterial.hpp"
+#include <cmath>
+
+Raytracer::Chessboard::Chessboard(Raytracer::MaterialOptions options) : AMaterial(options)
+{
+    _options.properties.reflexion = 0.1;
+}
+
+extern "C" Raytracer::IMaterial *materialEntrypoint(Raytracer::MaterialOptions options)
+{
+    return new Raytracer::Chessboard(options);
+}
+
+Raytracer::Color Raytracer::Chessboard::applyMaterial(Color ac_color, Math::Point3D pos) const
+{
+    if (std::abs(static_cast<int>(std::floor(pos.x * 0.1)) % 2) == std::abs(static_cast<int>(std::floor((pos.z * 0.1))) % 2) == std::abs(static_cast<int>(std::floor(((pos.y + 1.0) * 0.1))) % 2)) // avec le +1 ça marche donc je le laisse mdr
+        return ac_color;
+    return Color(0,0,0);
+}

--- a/src/materials/Makefile
+++ b/src/materials/Makefile
@@ -23,7 +23,6 @@ CHESSBOARD_SRC	:=	$(COMMON_SRC) \
 CHESSBOARD_OBJ	:=	$(CHESSBOARD_SRC:.cpp=.o)
 CHESSBOARD_BIN	:=	$(PLUGINS_DIR)/raytracer_material_chessboard.so
 
-
 include $(BASE_DIR)/common.mk
 
 all:	$(FLAT_COLOR_BIN) $(METALLIC_BIN) $(TRANSPARENT_BIN) $(CHESSBOARD_BIN)
@@ -45,10 +44,8 @@ clean:
 fclean:	clean
 	$(RM) $(FLAT_COLOR_BIN)
 	$(RM) $(METALLIC_BIN)
-	$(RM) $(METALLIC_BIN)
+	$(RM) $(TRANSPARENT_BIN)
 	$(RM) $(CHESSBOARD_BIN)
-
-
 
 re:	fclean all
 

--- a/src/materials/Makefile
+++ b/src/materials/Makefile
@@ -18,9 +18,15 @@ TRANSPARENT_SRC	:=	$(COMMON_SRC) \
 TRANSPARENT_OBJ	:=	$(TRANSPARENT_SRC:.cpp=.o)
 TRANSPARENT_BIN	:=	$(PLUGINS_DIR)/raytracer_material_transparent.so
 
+CHESSBOARD_SRC	:=	$(COMMON_SRC) \
+					Chessboard.cpp
+CHESSBOARD_OBJ	:=	$(CHESSBOARD_SRC:.cpp=.o)
+CHESSBOARD_BIN	:=	$(PLUGINS_DIR)/raytracer_material_chessboard.so
+
+
 include $(BASE_DIR)/common.mk
 
-all:	$(FLAT_COLOR_BIN) $(METALLIC_BIN) $(TRANSPARENT_BIN)
+all:	$(FLAT_COLOR_BIN) $(METALLIC_BIN) $(TRANSPARENT_BIN) $(CHESSBOARD_BIN)
 
 $(METALLIC_BIN): $(METALLIC_OBJ)
 
@@ -28,15 +34,20 @@ $(FLAT_COLOR_BIN): $(FLAT_COLOR_OBJ)
 
 $(TRANSPARENT_BIN): $(TRANSPARENT_OBJ)
 
+$(CHESSBOARD_BIN): $(CHESSBOARD_OBJ)
+
 clean:
 	$(RM) $(FLAT_COLOR_OBJ)
 	$(RM) $(METALLIC_OBJ)
 	$(RM) $(TRANSPARENT_OBJ)
+	$(RM) $(CHESSBOARD_OBJ)
 
 fclean:	clean
 	$(RM) $(FLAT_COLOR_BIN)
 	$(RM) $(METALLIC_BIN)
 	$(RM) $(METALLIC_BIN)
+	$(RM) $(CHESSBOARD_BIN)
+
 
 
 re:	fclean all

--- a/src/materials/Transparent.cpp
+++ b/src/materials/Transparent.cpp
@@ -1,13 +1,13 @@
-#include "materials/Metallic.hpp"
+#include "materials/Transparent.hpp"
 #include "materials/AMaterial.hpp"
 #include "materials/IMaterial.hpp"
 
-Raytracer::Metallic::Metallic(Raytracer::MaterialOptions options) : AMaterial(options)
+Raytracer::Transparent::Transparent(Raytracer::MaterialOptions options) : AMaterial(options)
 {
-    _options.properties.transparency = 0.6;   
+    _options.properties.transparency = 0.6;
 }
 
 extern "C" Raytracer::IMaterial *materialEntrypoint(Raytracer::MaterialOptions options)
 {
-    return new Raytracer::Metallic(options);
+    return new Raytracer::Transparent(options);
 }


### PR DESCRIPTION
Previous chessboard implementation was reverted in #26 due to problems on my end where my object files didn't recompile properly.

This has now been fixed with another fix where the wrong material was constructed in `Transparent.cpp`

Nothing has changed implementation wise, this is why I'm only requesting @Nadal-B.

`make fclean` is finally working:
```sh
make fclean
find . -name "*.o"
find . -name "*.so"
```

---

As for the testing that was asked with other material types, it definitely does work. Only metallic yields a weird result:

<img width="500" alt="chessboard_transparent_sphere" src="https://github.com/user-attachments/assets/a9ee5fa9-46b2-4e9c-a664-47928ae5fdec" />

Otherwise, everything else looks good.

No problems were found with valgrind or ASAN